### PR TITLE
Make S3.list_objects work with stream! and prefix

### DIFF
--- a/lib/ex_aws/s3/lazy.ex
+++ b/lib/ex_aws/s3/lazy.ex
@@ -9,22 +9,20 @@ defmodule ExAws.S3.Lazy do
     end
 
     Stream.resource(fn -> {request_fun, []} end, fn
-      :quit -> {:halt, nil}
+      :quit ->
+        {:halt, nil}
 
-      {fun, args} -> case fun.(args) do
+      {fun, args} ->
+        results = fun.(args)
+        contents = Map.get(results, :contents, [])
+        common_prefixes = Map.get(results, :common_prefixes, [])
 
-	      results = %{contents: contents = [_|_], is_truncated: "true"} ->
-          {contents, {fun, [marker: next_marker(results)]}}
-
-	      %{contents: contents = [_|_]} ->
-          {contents, :quit}
-
-        results = %{common_prefixes: common_prefixes = [_|_], is_truncated: "true"} ->
-          {common_prefixes, {fun, [marker: next_marker(results)]}}
-
-        %{common_prefixes: common_prefixes} ->
-          {common_prefixes, :quit}
-      end
+        case results do
+          %{is_truncated: "true"} ->
+            {contents ++ common_prefixes, {fun, [marker: next_marker(results)]}} 
+          _ ->
+            {contents ++ common_prefixes, :quit}
+        end
     end, &(&1))
   end
 

--- a/lib/ex_aws/s3/lazy.ex
+++ b/lib/ex_aws/s3/lazy.ex
@@ -13,11 +13,17 @@ defmodule ExAws.S3.Lazy do
 
       {fun, args} -> case fun.(args) do
 
-        results = %{contents: contents, is_truncated: "true"} ->
+	      results = %{contents: contents = [_|_], is_truncated: "true"} ->
           {contents, {fun, [marker: next_marker(results)]}}
 
-        %{contents: contents} ->
+	      %{contents: contents = [_|_]} ->
           {contents, :quit}
+
+        results = %{common_prefixes: common_prefixes = [_|_], is_truncated: "true"} ->
+          {common_prefixes, {fun, [marker: next_marker(results)]}}
+
+        %{common_prefixes: common_prefixes} ->
+          {common_prefixes, :quit}
       end
     end, &(&1))
   end

--- a/test/lib/ex_aws/s3/integration_test.exs
+++ b/test/lib/ex_aws/s3/integration_test.exs
@@ -6,4 +6,53 @@ defmodule ExAws.S3IntegrationTest do
     assert %{buckets: _} = body
   end
 
+  test "#list_objects with stream! with delimiter (with no results)" do
+    {:ok, %{body: %{buckets: [%{name: bucket} | _rest]}}} = ExAws.S3.list_buckets |> ExAws.request
+
+    results = ExAws.S3.list_objects(bucket, delimiter: "/", prefix: "zzzyyyxxxwww") |> ExAws.stream! |> Enum.to_list
+
+    assert [] = results
+  end
+
+  test "#list_objects with stream! with delimiter (folders, will not paginate)" do
+    {:ok, %{body: %{buckets: [%{name: bucket} | _rest]}}} = ExAws.S3.list_buckets |> ExAws.request
+
+    results = ExAws.S3.list_objects(bucket, delimiter: "/", prefix: "folders/short/") |> ExAws.stream! |> Enum.to_list
+
+    assert [
+      %{prefix: "folders/short/0001/"},
+      %{prefix: "folders/short/0002/"},
+      %{prefix: "folders/short/0003/"}
+    ] = results
+  end
+
+  test "#list_objects with stream! with delimiter (folders, will paginate)" do
+    {:ok, %{body: %{buckets: [%{name: bucket} | _rest]}}} = ExAws.S3.list_buckets |> ExAws.request
+
+    results = ExAws.S3.list_objects(bucket, delimiter: "/", prefix: "folders/long/") |> ExAws.stream! |> Enum.to_list
+
+    assert [%{prefix: "folders/long/0001/"} | _t] = results
+    assert length(results) == 1200
+  end
+
+  test "#list_objects with stream! with delimiter (objects, will not paginate)" do
+    {:ok, %{body: %{buckets: [%{name: bucket} | _rest]}}} = ExAws.S3.list_buckets |> ExAws.request
+
+    results = ExAws.S3.list_objects(bucket, delimiter: "/", prefix: "objects/short/") |> ExAws.stream! |> Enum.to_list
+
+    assert [
+      %{e_tag: _, key: "objects/short/0001"},
+      %{e_tag: _, key: "objects/short/0002"},
+      %{e_tag: _, key: "objects/short/0003"},
+    ] = results
+  end
+
+  test "#list_objects with stream! with delimiter (objects, will paginate)" do
+    {:ok, %{body: %{buckets: [%{name: bucket} | _rest]}}} = ExAws.S3.list_buckets |> ExAws.request
+
+    results = ExAws.S3.list_objects(bucket, delimiter: "/", prefix: "objects/long/") |> ExAws.stream! |> Enum.to_list
+
+    assert [%{e_tag: _, key: "objects/long/0001"} | _t] = results
+    assert length(results) == 1200
+  end
 end

--- a/test/lib/ex_aws/s3/integration_test.exs
+++ b/test/lib/ex_aws/s3/integration_test.exs
@@ -55,4 +55,49 @@ defmodule ExAws.S3IntegrationTest do
     assert [%{e_tag: _, key: "objects/long/0001"} | _t] = results
     assert length(results) == 1200
   end
+
+  test "#list_objects with stream! with delimiter (neither paginate)" do
+    {:ok, %{body: %{buckets: [%{name: bucket} | _rest]}}} = ExAws.S3.list_buckets |> ExAws.request
+
+    results = ExAws.S3.list_objects(bucket, delimiter: "/", prefix: "mixed/neither_paginate/") |> ExAws.stream! |> Enum.to_list
+
+    assert [
+      %{e_tag: _, key: "mixed/neither_paginate/0001"},
+      %{e_tag: _, key: "mixed/neither_paginate/0002"},
+      %{e_tag: _, key: "mixed/neither_paginate/0003"},
+      %{prefix: "mixed/neither_paginate/d0001/"},
+      %{prefix: "mixed/neither_paginate/d0002/"},
+      %{prefix: "mixed/neither_paginate/d0003/"},
+    ] = results
+  end
+
+  test "#list_objects with stream! with delimiter (both paginate)" do
+    {:ok, %{body: %{buckets: [%{name: bucket} | _rest]}}} = ExAws.S3.list_buckets |> ExAws.request
+
+    results = ExAws.S3.list_objects(bucket, delimiter: "/", prefix: "mixed/both_paginate/") |> ExAws.stream! |> Enum.to_list
+
+    assert length(results) == 2400
+    assert 1200 = length(for %{e_tag: e} <- results, do: e)
+    assert 1200 = length(for %{prefix: e} <- results, do: e)
+  end
+
+  test "#list_objects with stream! with delimiter (objects paginate)" do
+    {:ok, %{body: %{buckets: [%{name: bucket} | _rest]}}} = ExAws.S3.list_buckets |> ExAws.request
+
+    results = ExAws.S3.list_objects(bucket, delimiter: "/", prefix: "mixed/objects_paginate/") |> ExAws.stream! |> Enum.to_list
+
+    assert length(results) == 1203
+    assert 1200 = length(for %{e_tag: e} <- results, do: e)
+    assert 3 = length(for %{prefix: e} <- results, do: e)
+  end
+
+  test "#list_objects with stream! with delimiter (folders paginate)" do
+    {:ok, %{body: %{buckets: [%{name: bucket} | _rest]}}} = ExAws.S3.list_buckets |> ExAws.request
+
+    results = ExAws.S3.list_objects(bucket, delimiter: "/", prefix: "mixed/folders_paginate/") |> ExAws.stream! |> Enum.to_list
+
+    assert length(results) == 1203
+    assert 3 = length(for %{e_tag: e} <- results, do: e)
+    assert 1200 = length(for %{prefix: e} <- results, do: e)
+  end
 end


### PR DESCRIPTION
I have a fixture bucket that I created in the account I was using. The best approach would be local fixtures, but I can send you the format of the bucket (or you can duplicate from tests). I ran into corner cases that required each of these.

```
# for testing delimiter without pagination
bucket/folders/short/0001/keep
bucket/folders/short/0002/keep
bucket/folders/short/0003/keep

# for testing delimiter with pagination
bucket/folders/long/0001/keep
...
bucket/folders/long/1200/keep

# for testing delimiter without pagination
bucket/objects/short/0001
bucket/objects/short/0002
bucket/objects/short/0003

# for testing delimiter with pagination
bucket/objects/long/0001
...
bucket/objects/long/1200
```