### PR TITLE
fixed CustomUserData if it’s nil

### DIFF
--- a/lib/ex_aws/sns.ex
+++ b/lib/ex_aws/sns.ex
@@ -157,11 +157,18 @@ defmodule ExAws.SNS do
                                    token :: binary,
                                    custom_user_data :: binary) :: ExAws.Operation.Query.t
   def create_platform_endpoint(platform_application_arn, token, custom_user_data \\ nil) do
-    request(:create_platform_endpoint, %{
+    attrs = %{
       "PlatformApplicationArn" => platform_application_arn,
-      "Token" => token,
-      "CustomUserData" => custom_user_data
-    })
+      "Token" => token
+    }
+    
+    attrs = if custom_user_data do
+      Map.put(attrs, "CustomUserData", custom_user_data)
+    else
+      attrs
+    end
+    
+    request(:create_platform_endpoint, attrs)
   end
 
   @doc "Get platform application attributes"

--- a/test/lib/ex_aws/sns/parser_test.exs
+++ b/test/lib/ex_aws/sns/parser_test.exs
@@ -605,6 +605,35 @@ defmodule ExAws.SNS.ParserTest do
     assert parsed_doc[:token] == "APA91bGi7fFachkC1xjlqT66VYEucGHochmf1VQAr9k...jsM0PKPxKhddCzx6paEsyay9Zn3D4wNUJb8m6HZrBEXAMPLE"
     assert parsed_doc[:request_id] == "6c725a19-a142-5b77-94f9-1055a9ea04e7"
   end
+  
+  test "#parsing a get_endpoint_attributes response with no CustomUserData" do
+    rsp = """
+      <GetEndpointAttributesResponse xmlns="http://sns.amazonaws.com/doc/2010-03-31/">
+        <GetEndpointAttributesResult>
+          <Attributes>
+            <entry>
+              <key>Enabled</key>
+              <value>true</value>
+            </entry>
+            <entry>
+              <key>Token</key>
+              <value>APA91bGi7fFachkC1xjlqT66VYEucGHochmf1VQAr9k...jsM0PKPxKhddCzx6paEsyay9Zn3D4wNUJb8m6HZrBEXAMPLE</value>
+            </entry>
+          </Attributes>
+        </GetEndpointAttributesResult>
+        <ResponseMetadata>
+          <RequestId>6c725a19-a142-5b77-94f9-1055a9ea04e7</RequestId>
+        </ResponseMetadata>
+      </GetEndpointAttributesResponse>
+    """
+    |> to_success
+
+    {:ok, %{body: parsed_doc}} = Parsers.parse(rsp, :get_endpoint_attributes)
+    assert parsed_doc[:enabled] == true
+    assert parsed_doc[:custom_user_data] == nil
+    assert parsed_doc[:token] == "APA91bGi7fFachkC1xjlqT66VYEucGHochmf1VQAr9k...jsM0PKPxKhddCzx6paEsyay9Zn3D4wNUJb8m6HZrBEXAMPLE"
+    assert parsed_doc[:request_id] == "6c725a19-a142-5b77-94f9-1055a9ea04e7"
+  end
 
   test "#parsing a set_endpoint_attributes response" do
     rsp = """

--- a/test/lib/ex_aws/sns_test.exs
+++ b/test/lib/ex_aws/sns_test.exs
@@ -60,6 +60,15 @@ defmodule ExAws.SNSTest do
     }
     assert expected == SNS.create_platform_endpoint("arn:aws:sns:us-west-1:00000000000:app/APNS/test-arn", "123abc456def", "user data").params
   end
+  
+  test "#create_platform_endpoint removes user data if it's nil" do
+    expected = %{
+      "Action" => "CreatePlatformEndpoint",
+      "PlatformApplicationArn" => "arn:aws:sns:us-west-1:00000000000:app/APNS/test-arn",
+      "Token" => "123abc456def"
+    }
+    assert expected == SNS.create_platform_endpoint("arn:aws:sns:us-west-1:00000000000:app/APNS/test-arn", "123abc456def", nil).params
+  end
 
   test "#list_platform_applications" do
     expected = %{"Action" => "ListPlatformApplications"}


### PR DESCRIPTION
I have run into a strange and confusing situation with SNS and ex_aws. Specifically when registering a device with `SNS.create_platform_endpoint`. Before this PR, a nil value for `custom_user_data` gets converted to an empty string `””` on AWS side.

Additionally, a device registered with another client (aws cli for example) that truly does have no custom user data incorrectly shows up with the custom_user_data as `””` with ex_aws.

This causes a problem because when re-registering a device (which you are allowed to do), and the custom user data does not match you will get an AWS error.

This PR prevents a nil `custom_user_data` param from getting sent to AWS (which causes the empty string to be set). It also removes the custom_user_data param when parsing a `GetEndpointAttributesResponse` response if there is no custom_user_data (instead of setting it to an empty string).