### PR TITLE
Cloudwatch PutMetric

### DIFF
--- a/lib/ex_aws/cloudwatch.ex
+++ b/lib/ex_aws/cloudwatch.ex
@@ -30,19 +30,29 @@ defmodule ExAws.Cloudwatch do
 
   @type put_metric_t :: { metric_counter :: integer, metrics :: list() }
   
-  @doc "Start a metric request"
-  @spec start_metric_data(namespace :: binary,
-    name :: binary,
-    value :: (binary | integer | float),
-    unit :: binary,
-    dimensions :: [ { dimension_name :: binary, dimension_value :: binary } ]
-  ) :: put_metric_t
+  @doc ~S"""
+  Start a metric request
+
+  iex> ExAws.Cloudwatch.start_metric_data("Support")
+  { 1, [namespace: "Support"] }
+
+  """
+  @spec start_metric_data(namespace :: binary) :: put_metric_t
   
-  def start_metric_data(namespace, name, value, unit, dimensions \\ []) do
-    add_metric_data( { 1, [namespace: namespace] }, name, value, unit, dimensions)
+  def start_metric_data(namespace) do
+    { 1, [namespace: namespace] }
   end
 
-  @doc "Add a metric"
+  @doc ~S"""
+  Add a metric
+
+  iex> ExAws.Cloudwatch.start_metric_data("Support") |> ExAws.Cloudwatch.add_metric_data("network", 1, "Count")
+{2,
+ [{"MetricData.member.1.MetricName", "network"},
+  {"MetricData.member.1.Value", 1}, {"MetricData.member.1.Unit", "Count"},
+  {:namespace, "Support"}]}
+
+  """
   @spec add_metric_data( metric_data :: put_metric_t,
     name :: binary,
     value :: (binary | integer | float),
@@ -69,7 +79,19 @@ defmodule ExAws.Cloudwatch do
     {metric_n+1, metric ++ metrics }
   end
 
-  @doc "Finalize metrics_data into a request"
+  @doc ~S"""
+  Finalize metrics_data into a request
+
+  iex> ExAws.Cloudwatch.start_metric_data("Support") |> ExAws.Cloudwatch.add_metric_data("network", 1, "Count") |> ExAws.Cloudwatch.put_metric_data
+%ExAws.Operation.Query{action: :put_metric_data,
+ params: %{"Action" => "PutMetricData",
+   "MetricData.member.1.MetricName" => "network",
+   "MetricData.member.1.Unit" => "Count", "MetricData.member.1.Value" => 1,
+   "Namespace" => "Support", "Version" => "2010-08-01"},
+ parser: &ExAws.Cloudwatch.Parsers.parse/2, path: "/", service: :monitoring}
+
+  """
+  
   @spec put_metric_data( metric_data :: put_metric_t ) :: ExAws.Operation.Query.t
   def put_metric_data( { _metric_n, metrics } ) do
     put_metric_data(metrics)

--- a/lib/ex_aws/cloudwatch.ex
+++ b/lib/ex_aws/cloudwatch.ex
@@ -55,7 +55,7 @@ defmodule ExAws.Cloudwatch do
 
     dimensions = Enum.with_index(dimensions)
     |> Enum.flat_map(fn { {d_name, d_value}, idx} ->
-      dn = key <> "Dimensions.member.#{idx}."
+      dn = key <> "Dimensions.member.#{idx+1}."
       [
 	{ dn <> "Name", d_name}, 
 	{ dn <> "Value", d_value}

--- a/test/lib/ex_aws/cloudwatch_test.exs
+++ b/test/lib/ex_aws/cloudwatch_test.exs
@@ -2,6 +2,8 @@ defmodule ExAws.CloudwatchTest do
   use ExUnit.Case, async: true
   alias ExAws.Cloudwatch
 
+  doctest ExAws.Cloudwatch
+  
   test "#describe_alarms" do
     expected = %{"Action" => "DescribeAlarms", "Version" => "2010-08-01"}
     assert expected == Cloudwatch.describe_alarms().params


### PR DESCRIPTION
The PR includes PutMetric for Cloudwatch. Since a single PutMetric can include many individual metrics and dimensions, the approach is compositional and is expected to be used in a pipeline. This PR is primarily to find out if this (or another) approach is palatable and to solicit any comments on alternatives.

An example:

ExAws.Cloudwatch.start_metric_data("Support", "out", 50, "Count", source: "generator")
|> ExAws.Cloudwatch.add_metric_data("in", 47, "Count", source: "network") 
|> ExAws.Cloudwatch.put_metric_data
|> ExAws.request
