### PR TITLE
Update the CONTRIBUTING required policy document to include cloudformation permissions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,9 @@ Running the test suite for ex_aws requires a few things:
         "firehose:ListDeliveryStreams",
         "ses:VerifyEmailIdentity",
         "elastictranscoder:ListPipelines",
-        "cloudwatch:DescribeAlarms"
+        "cloudwatch:DescribeAlarms",
+        "cloudformation:DescribeStacks",
+        "cloudformation:ListStacks"
       ],
       "Resource": "*"
     }


### PR DESCRIPTION
Running mix test limited to the IAM permissions currently specified in the contributing document results in failures on Cloudformation integration tests.

This is a simple update to add the necessary permissions to the contributing document