### PR TITLE
Fix typespec of `tag_specification`

### DIFF
--- a/lib/ex_aws/ec2.ex
+++ b/lib/ex_aws/ec2.ex
@@ -66,7 +66,7 @@ defmodule ExAws.EC2 do
   @type tag :: {key :: atom, value :: binary}
 
   @type tag_specification :: {
-    resource_type :: binary,
+    resource_type :: atom,
     tags :: [tag, ...]
   }
 


### PR DESCRIPTION
Follow to this document, the following error occurs: 
```elixir
iex(2)> ExAws.EC2.run_instances("ami-123456", 1, 1, [tag_specifications: [{"instance", [Name: "Test"]}]])
** (ArgumentError) argument error
    :erlang.atom_to_binary("instance", :utf8)
    (ex_aws) lib/ex_aws/ec2.ex:2758: anonymous fn/2 in ExAws.EC2.format_param/1
    (elixir) lib/enum.ex:1255: Enum."-map/2-lists^map/1-0-"/2
    (ex_aws) lib/ex_aws/ec2.ex:2763: ExAws.EC2.format_param/1
    (elixir) lib/enum.ex:988: Enum.flat_map_list/2
    (elixir) lib/enum.ex:989: Enum.flat_map_list/2
    (ex_aws) lib/ex_aws/ec2.ex:2624: ExAws.EC2.build_request/2
```
but, success when follow to modified typespec: 
```elixir
iex(2)> ExAws.EC2.run_instances("ami-123456", 1, 1, [tag_specifications: [{:instance, [Name: "Test"]}]])
%ExAws.Operation.Query{action: :run_instances,
 params: %{"Action" => "RunInstances", "ImageId" => "ami-123456",
   "MaxCount" => 1, "MinCount" => 1,
   "TagSpecification.1.ResourceType" => "instance",
   "TagSpecification.1.Tag.1.Key" => "Name",
   "TagSpecification.1.Tag.1.Value" => "Test", "Version" => "2016-11-15"},
 parser: &ExAws.Utils.identity/2, path: "/", service: :ec2}
```

using `Atom.to_string/1` in code: https://github.com/CargoSense/ex_aws/blob/e2e07245fbcc9c2e5bf49c04f1a69448ec2fa27d/lib/ex_aws/ec2.ex#L2758 