### PR TITLE
Adding support for ExternalId parameter on sts:AssumeRole

### DIFF
--- a/lib/ex_aws/sts.ex
+++ b/lib/ex_aws/sts.ex
@@ -91,4 +91,5 @@ defmodule ExAws.STS do
   defp parse_opt(opts, {:token_code, val}), do: Map.put(opts, "TokenCode", val)
   defp parse_opt(opts, {:serial_number, val}), do: Map.put(opts, "SerialNumber", val)
   defp parse_opt(opts, {:policy, val}), do: Map.put(opts, "Policy", Poison.encode!(val))
+  defp parse_opt(opts, {:external_id, val}), do: Map.put(opts, "ExternalId", val)
 end


### PR DESCRIPTION
ExternalId is supported in the type spec but wasn't supported in the option parser. Just added the line in so :external_id can now be used.