### PR TITLE
Fix double slash on instance metadata queries

### DIFF
--- a/lib/ex_aws/instance_meta.ex
+++ b/lib/ex_aws/instance_meta.ex
@@ -6,7 +6,7 @@ defmodule ExAws.InstanceMeta do
   # http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html
 
   # AWS InstanceMetaData URL
-  @meta_path_root "http://169.254.169.254/latest/meta-data/"
+  @meta_path_root "http://169.254.169.254/latest/meta-data"
 
   # Endpoint for ECS taks role credentials
   # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html


### PR DESCRIPTION
When building paths to retrieve instance metadata, you would end up with double slashes: http://169.254.169.254/latest/meta-data*//*iam/security-credentials/

AWS instance metadata doesn't seem to care about the double slash, but when using services like kube2iam in order to expose IAM profiles to Kubernetes pods, sometimes they do care and won't work.

After merging, can you release a new version? I depend on this and I don't want to be using deps from git.