### PR TITLE
Fix errors to make it ready for Elixir 1.6

### DIFF
--- a/lib/ex_aws/s3/download.ex
+++ b/lib/ex_aws/s3/download.ex
@@ -71,7 +71,7 @@ defimpl ExAws.Operation, for: ExAws.S3.Download do
       :ok = :file.pwrite(file, [chunk])
     end,
       max_concurrency: Keyword.get(op.opts, :max_concurrency, 8),
-      timeout: Keyword.get(op.opts, :timeout, 30_000),
+      timeout: Keyword.get(op.opts, :timeout, 30_000)
     )
     |> Stream.run
 

--- a/lib/ex_aws/s3/upload.ex
+++ b/lib/ex_aws/s3/upload.ex
@@ -84,7 +84,7 @@ defimpl ExAws.Operation, for: ExAws.S3.Upload do
       |> Stream.with_index(1)
       |> Task.async_stream(&Upload.upload_chunk!(&1, op, config),
         max_concurrency: Keyword.get(op.opts, :max_concurrency, 4),
-        timeout: Keyword.get(op.opts, :timeout, 30_000),
+        timeout: Keyword.get(op.opts, :timeout, 30_000)
       )
       |> Enum.to_list
       |> Enum.map(fn {:ok, val} -> val end)

--- a/lib/ex_aws/sqs/parsers.ex
+++ b/lib/ex_aws/sqs/parsers.ex
@@ -138,7 +138,7 @@ if Code.ensure_loaded?(SweetXml) do
                         request_id: request_id_xpath(),
                         message_id: ~x"./SendMessageResult/MessageId/text()"s,
                         md5_of_message_body: ~x"./SendMessageResult/MD5OfMessageBody/text()"s,
-                        md5_of_message_attributes: ~x"./SendMessageResult/MD5OfMessageAttributes/text()"s,
+                        md5_of_message_attributes: ~x"./SendMessageResult/MD5OfMessageAttributes/text()"s
       )
 
       {:ok, Map.put(resp, :body, parsed_body)}


### PR DESCRIPTION
These extra commas results into error when compiled with Elixir 1.6
e.g.

```
== Compilation error in file lib/ex_aws/s3/download.ex ==
** (SyntaxError) lib/ex_aws/s3/download.ex:75: syntax error before: ')'
    (elixir) lib/kernel/parallel_compiler.ex:160: anonymous fn/4 in Kernel.ParallelCompiler.spawn_workers/1
```

```
== Compilation error in file lib/ex_aws/s3/upload.ex ==
** (SyntaxError) lib/ex_aws/s3/upload.ex:88: syntax error before: ')'
    (elixir) lib/kernel/parallel_compiler.ex:160: anonymous fn/4 in Kernel.ParallelCompiler.spawn_workers/1
```

```

== Compilation error in file lib/ex_aws/sqs/parsers.ex ==
** (SyntaxError) lib/ex_aws/sqs/parsers.ex:142: syntax error before: ')'
    (elixir) lib/kernel/parallel_compiler.ex:160: anonymous fn/4 in Kernel.ParallelCompiler.spawn_workers/1
```