### PR TITLE
Fix: parsing config causes unused processes to accumulate

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ This means it will try to resolve credentials in order
 AWS CLI config files are supported, but require an additional dependency:
 
 ```elixir
-{:configparser_ex, "~> 0.2.1"}
+{:configparser_ex, "~> 2.0"}
 ```
 
 You can then add `{:awscli, "profile_name", timeout}` to the above config and it

--- a/mix.exs
+++ b/mix.exs
@@ -41,7 +41,7 @@ defmodule ExAws.Mixfile do
       {:jsx, "~> 2.8", optional: true},
       {:dialyze, "~> 0.2.0", only: [:dev, :test]},
       {:bypass, "~> 0.7", only: :test},
-      {:configparser_ex, "~> 0.2.1", optional: true},
+      {:configparser_ex, "~> 2.0", optional: true},
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
 %{"bypass": {:hex, :bypass, "0.7.0", "591d2ac1d87ba1bb84f62656a79de2fe3909993a211021a881825b59c9f7f58f", [:mix], [{:cowboy, "~> 1.0", [repo: "hexpm", hex: :cowboy, optional: false]}, {:plug, "~> 1.0", [repo: "hexpm", hex: :plug, optional: false]}], "hexpm"},
   "certifi": {:hex, :certifi, "1.2.1", "c3904f192bd5284e5b13f20db3ceac9626e14eeacfbb492e19583cf0e37b22be", [:rebar3], [], "hexpm"},
-  "configparser_ex": {:hex, :configparser_ex, "0.2.1", "47a15fa6ebc7d5284bd6dbe1a88be7315fde91a1328915739509c5b75e26eb93", [:mix], []},
+  "configparser_ex": {:hex, :configparser_ex, "2.0.1", "71a002cbb220ad8a2d31a9cbedd590ddcee30534fb1513fe4545c64d417847c5", [], [], "hexpm"},
   "cowboy": {:hex, :cowboy, "1.1.2", "61ac29ea970389a88eca5a65601460162d370a70018afe6f949a29dca91f3bb0", [:rebar3], [{:cowlib, "~> 1.0.2", [repo: "hexpm", hex: :cowlib, optional: false]}, {:ranch, "~> 1.3.2", [repo: "hexpm", hex: :ranch, optional: false]}], "hexpm"},
   "cowlib": {:hex, :cowlib, "1.0.2", "9d769a1d062c9c3ac753096f868ca121e2730b9a377de23dec0f7e08b1df84ee", [:make], []},
   "dialyze": {:hex, :dialyze, "0.2.1", "9fb71767f96649020d769db7cbd7290059daff23707d6e851e206b1fdfa92f9d", [:mix], []},


### PR DESCRIPTION
When `:aws_instance_auth` & `:awscli` config are expired,  `ExAws.Config.AuthCache.get` is called for loading config at runtime. And every time called, some processes have generated and still alive through app running.
That is caused by `StringIO.open(config_string)` is used for reading string then return result without closing it (`StringIO.close(pid)`).
It is fixed and available in `configparser_ex` 2.0.1 version now.

[https://github.com/easco/configparser_ex/releases/tag/2.0.1](https://github.com/easco/configparser_ex/releases/tag/2.0.1)