### PR TITLE
Allow for custom headers and allow override of content-type.

### DIFF
--- a/lib/ex_aws/auth.ex
+++ b/lib/ex_aws/auth.ex
@@ -29,11 +29,16 @@ defmodule ExAws.Auth do
   def headers(http_method, url, service, config, headers, body) do
     with {:ok, config} <- validate_config(config) do
       datetime = :calendar.universal_time
-      headers = [
-        {"host", URI.parse(url).authority},
-        {"x-amz-date", amz_date(datetime)} |
-        headers
-      ]
+
+      headers = Map.get(config, :headers, [])  # Get headers from config, if they exist
+      |> List.wrap
+      |> Enum.concat(
+        [
+          {"host", URI.parse(url).authority},
+          {"x-amz-date", amz_date(datetime)} |
+          headers
+        ]
+      )
       |> handle_temp_credentials(config)
 
       auth_header = auth_header(

--- a/test/lib/ex_aws/auth_test.exs
+++ b/test/lib/ex_aws/auth_test.exs
@@ -1,6 +1,7 @@
 defmodule ExAws.AuthTest do
   use ExUnit.Case, async: true
   import ExAws.Auth, only: [
+    headers: 6,
     build_canonical_request: 5
   ]
   import ExAws.Auth.Utils, only: [
@@ -12,6 +13,24 @@ defmodule ExAws.AuthTest do
     secret_access_key: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
     region: "us-east-1"
   }
+
+  test "headers includes headers from config" do
+    headers_config = Map.merge(@config, %{
+        headers: [
+          {"Fancy-Header-A", "So Fancy"},
+          {"Fancy-Header-B", "More Fancy"}
+        ]
+    })
+
+    # Cram the generated headers into a map for easy lookup
+    result = headers(:post, "http://localhost/path", :test, headers_config, [], "")
+    |> elem(1)
+    |> Enum.into(%{})
+
+    assert result["Fancy-Header-A"] == "So Fancy"
+    assert result["Fancy-Header-B"] == "More Fancy"
+    assert result["Authorization"] =~ "fancy-header-a;fancy-header-b"
+  end
 
   test "build_canonical_request can handle : " do
     expected = "GET\n/bar%3Abaz%40blag\n\n\n\n\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"


### PR DESCRIPTION
Allows passings :headers and :content_type in the config. This supports the X-Amz-Target header for AWS API and a Content-Type for a json payload. Example DescribeLogStreams call from Cloudwatch API:

    config = ExAws.Config.new(:logs) |> Map.merge(%{
        debug_requests: true,
        headers: [{"X-Amz-Target", "Logs_20140328.DescribeLogStreams"}],
        content_type: "application/x-amz-json-1.1"
    })

    query = %ExAws.Operation.Query{
       path: "/",
       params: %{
        "descending" => true,
        "limit" => 1,
        "logGroupName" => "groupName",
        "logStreamNamePrefix" => "streamName"
       },
       service: :logs,
       action: "Logs_20140328.DescribeLogStreams"
    } 
    |> ExAws.request(config)

Caveat: I am new to Elixir so please point out any goofy code.