### PR TITLE
Show an explicit example of changing hackney options

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,16 @@ config :ex_aws,
   secret_access_key: [{:system, "AWS_SECRET_ACCESS_KEY"}, {:awscli, "default", 30}, :instance_role],
 ```
 
+#### Hackney configuration
+
+ExAws by default uses [hackney](https://github.com/benoitc/hackney) to make HTTP requests to AWS API. You can modify the options as such:
+
+```elixir
+config :ex_aws, :hackney_opts,
+  follow_redirect: true,
+  recv_timeout: 30_000
+```
+
 ## Direct Usage
 
 ExAws can also be used directly without any specific service module.


### PR DESCRIPTION
When we used ex_aws on Kubernetes, with a proxy between the machine and AWS API, the default setup would not work as the requests to the instance meta [would only work if the response was 200](https://github.com/ex-aws/ex_aws/blob/master/lib/ex_aws/instance_meta.ex#L17). The proxy for us was doing a 301 or 302 redirect, so it'd fail.

Traced back the options being passed around to some defaults that don't have the `follow_redirect` flag set, realised we can overwrite those.

Hoping the explicit mention in the README helps the next person with this problem in the future. :)

/cc @zzeniou86