### PR TITLE
Region of service and common config is ignored

### DIFF
--- a/lib/ex_aws/config.ex
+++ b/lib/ex_aws/config.ex
@@ -32,10 +32,10 @@ defmodule ExAws.Config do
   end
 
   def build_base(service, overrides \\ %{}) do
-    region = Map.get(overrides, :region, "us-east-1")
-    defaults = ExAws.Config.Defaults.get(service, region)
     common_config = Application.get_all_env(:ex_aws) |> Map.new |> Map.take(@common_config)
     service_config = Application.get_env(:ex_aws, service, []) |> Map.new
+    region = Map.get(overrides, :region) || Map.get(service_config, :region) || Map.get(common_config, :region) || "us-east-1"
+    defaults = ExAws.Config.Defaults.get(service, region)
 
     defaults
     |> Map.merge(common_config)


### PR DESCRIPTION
Hi, thank you for great product ex_aws.

In `ExAws.Config.build_base/2` region string is passed to `ExAws.Config.Defaults.get/2`, however this comes from `overrides` and falls back to "us-east-1". This behaviour ignores region configuration in `common_config` or `service_config`. leads to getting an error such as reported in #359

