### PR TITLE
Fix config crash with custom region

### DIFF
--- a/lib/ex_aws/config/defaults.ex
+++ b/lib/ex_aws/config/defaults.ex
@@ -44,11 +44,20 @@ defmodule ExAws.Config.Defaults do
   ]
 
   def host(service, region) do
-    {_, partition} = Enum.find(@partitions, fn {regex, _} ->
-      Regex.run(regex, region)
-    end)
+    if partition = find_partition(region) do
+      do_host(partition, service, region)
+    end
+  end
 
-    do_host(partition, service, region)
+  defp find_partition(region) do
+    @partitions
+    |> Stream.map(fn {regex, _} ->
+        case Regex.run(regex, region) do
+          {_, partition} -> partition
+          _ -> nil
+        end
+    end)
+    |> Enum.find(&(&1))
   end
 
   defp service_map(:ses), do: "email"

--- a/test/ex_aws/config_test.exs
+++ b/test/ex_aws/config_test.exs
@@ -43,4 +43,10 @@ defmodule ExAws.ConfigTest do
 
     assert config.region == "eu-west-1"
   end
+
+  test "allow custom host & region" do
+    config = ExAws.Config.new(:s3, [host: %{"nyc3" => "nyc3.digitaloceanspaces.com"}, region: "nyc3"])
+    assert config.region == "nyc3"
+    assert config.host == "nyc3.digitaloceanspaces.com"
+  end
 end


### PR DESCRIPTION
Description
-----

When `Config` used with custom region, in my case unsupported by Amazon, it crashes with error:

```
ExAws.Config.new(:s3, [host: %{"nyc3" => "nyc3.digitaloceanspaces.com"}, region: "nyc3"])
** (MatchError) no match of right hand side value: nil
    (ex_aws) lib/ex_aws/config/defaults.ex:47: ExAws.Config.Defaults.host/2
    (ex_aws) lib/ex_aws/config/defaults.ex:37: ExAws.Config.Defaults.get/2
    (ex_aws) lib/ex_aws/config.ex:38: ExAws.Config.build_base/2
    (ex_aws) lib/ex_aws/config.ex:29: ExAws.Config.new/2
```

So, now defaults in `Config` should skip host creation in case if missing predefined aws partition.

### Reasoning behind fix
There are couple of aws-api compatible cloud storages out there, for example [DigitalOcean Spaces](https://www.digitalocean.com/products/object-storage/). It would be nice if `ex_aws` were able to work with them.