### PR TITLE
Fixing typo in import statement for README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ defp deps do
     {:ex_aws, "~> 2.0"},
     {:ex_aws_s3, "~> 2.0"},
     {:hackney, "~> 1.9"},
-    {:sweet_xml, "~ 0.6"},
+    {:sweet_xml, "~> 0.6"},
   ]
 end
 ```


### PR DESCRIPTION
The `:sweet_xml` import is missing an arrow in the docs, which makes it an invalid config setting when copy/pasted. Fixing the typo.