### PR TITLE
generate a presigned URL with body content

### DIFF
--- a/lib/ex_aws/auth.ex
+++ b/lib/ex_aws/auth.ex
@@ -49,7 +49,7 @@ defmodule ExAws.Auth do
     end
   end
 
-  def presigned_url(http_method, url, service, datetime, config, expires, query_params \\ []) do
+  def presigned_url(http_method, url, service, datetime, config, expires, query_params \\ [], body \\ nil) do
     with {:ok, config} <- validate_config(config) do
       service = service_name(service)
       headers = presigned_url_headers(url)
@@ -70,7 +70,7 @@ defmodule ExAws.Auth do
 
       path = uri_encode(path)
 
-      signature = signature(http_method, path, query_to_sign, headers, nil, service, datetime, config)
+      signature = signature(http_method, path, query_to_sign, headers, body, service, datetime, config)
       {:ok, "#{uri.scheme}://#{uri.authority}#{path}?#{query_for_url}&X-Amz-Signature=#{signature}"}
     end
   end
@@ -95,7 +95,6 @@ defmodule ExAws.Auth do
   defp signature(http_method, path, query, headers, body, service, datetime, config) do
     request = build_canonical_request(http_method, path, query, headers, body)
     string_to_sign = string_to_sign(request, service, datetime, config)
-
     Signatures.generate_signature_v4(service, config, datetime, string_to_sign)
   end
 

--- a/test/ex_aws/auth_test.exs
+++ b/test/ex_aws/auth_test.exs
@@ -65,4 +65,27 @@ defmodule ExAws.AuthTest do
 
     assert {:ok, expected} == actual
   end
+
+  test "presigned url with empty request body" do
+    # Required for RDS generate_db_token
+    # Data taken from botocore https://github.com/boto/botocore/blob/master/tests/unit/test_signers.py#L922
+    http_method = :get
+    url = "https://prod-instance.us-east-1.rds.amazonaws.com:3306/"
+    service = :"rds-db"
+    datetime = {{2016, 11, 7}, {17, 39, 33}}
+    expires = 900
+    query_params = ["Action": "connect", "DBUser": "someusername"]
+    body = ""
+    config = %{access_key_id: "akid", secret_access_key: "skid", region: "us-east-1"}
+    actual = ExAws.Auth.presigned_url(http_method, url, service, datetime, config, expires, query_params, body)
+
+    expected =
+      "https://prod-instance.us-east-1.rds.amazonaws.com:3306/?Action=connect"
+                <> "&DBUser=someusername&X-Amz-Algorithm=AWS4-HMAC-SHA256"
+                <> "&X-Amz-Credential=akid%2F20161107%2Fus-east-1%2Frds-db%2Faws4_request"
+                <> "&X-Amz-Date=20161107T173933Z&X-Amz-Expires=900&X-Amz-SignedHeaders=host"
+                <> "&X-Amz-Signature=d1138cdbc0ca63eec012ec0fc6c2267e03642168f5884a7795320d4c18374c61"
+
+    assert {:ok, expected} == actual
+  end
 end


### PR DESCRIPTION
This is a prerequisite for https://github.com/ex-aws/ex_aws_rds/issues/2. I could not find official documentation for implementing this behavior (they push you to the CLI), but I analyzed the botocore implementation to determine this. 

https://github.com/boto/botocore/blob/develop/botocore/auth.py#L262

They use some request metadata to automatically determine if a nil body should return the EMPTY_SHA256_HASH vs "UNSIGNED_PAYLOAD", but that seems like a much more invasive change - I can simply pass an empty string for the body content and `ExAws.Auth.build_canonical_request/5` will handle it correctly.