### PR TITLE
Add a hint that you can set the region in `ExAws.request/2`

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ end
 With these deps you can use `ExAws` precisely as you're used to:
 
 ```
-# make a request
+# make a request (with the default region)
+ExAws.S3.list_objects("my-bucket") |> ExAws.request
+# or specify the region
 ExAws.S3.list_objects("my-bucket") |> ExAws.request(region: "us-west-1")
 
 # some operations support streaming

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ With these deps you can use `ExAws` precisely as you're used to:
 
 ```
 # make a request
-ExAws.S3.list_objects("my-bucket") |> ExAws.request
+ExAws.S3.list_objects("my-bucket") |> ExAws.request(region: "us-west-1")
 
 # some operations support streaming
 ExAws.S3.list_objects("my-bucket") |> ExAws.stream! |> Enum.to_list


### PR DESCRIPTION
This is to help users who are not in `us-east-1` have a hint on how to get up and running faster.