### PR TITLE
Fix ExAws.Request.request_and_retry/7 case clause error where the body key is missing

### DIFF
--- a/lib/ex_aws/request.ex
+++ b/lib/ex_aws/request.ex
@@ -36,15 +36,16 @@ defmodule ExAws.Request do
       end
 
       case config[:http_client].request(method, url, req_body, full_headers, Map.get(config, :http_opts, [])) do
-        {:ok, response = %{status_code: status}} when status in 200..299 or status == 304 ->
-          {:ok, response}
+        {:ok, %{status_code: status} = resp} when status in 200..299 or status == 304 ->
+          {:ok, resp}
         {:ok, %{status_code: status} = resp} when status in 400..499 ->
           case client_error(resp, config[:json_codec]) do
             {:retry, reason} ->
               request_and_retry(method, url, service, config, headers, req_body, attempt_again?(attempt, reason, config))
             {:error, reason} -> {:error, reason}
           end
-        {:ok, %{status_code: status, body: body}} when status >= 500 ->
+        {:ok, %{status_code: status} = resp} when status >= 500 ->
+          body = Map.get(resp, :body)
           reason = {:http_error, status, body}
           request_and_retry(method, url, service, config, headers, req_body, attempt_again?(attempt, reason, config))
         {:error, %{reason: reason}} ->


### PR DESCRIPTION
Removes the `body` key matching in `ExAws.Request.request_and_retry/7`

Closes https://github.com/ex-aws/ex_aws/issues/525