### PR TITLE
Detect retryable errors properly

### DIFF
--- a/lib/ex_aws/request.ex
+++ b/lib/ex_aws/request.ex
@@ -36,15 +36,16 @@ defmodule ExAws.Request do
       end
 
       case config[:http_client].request(method, url, req_body, full_headers, Map.get(config, :http_opts, [])) do
-        {:ok, response = %{status_code: status}} when status in 200..299 or status == 304 ->
-          {:ok, response}
+        {:ok, %{status_code: status} = resp} when status in 200..299 or status == 304 ->
+          {:ok, resp}
         {:ok, %{status_code: status} = resp} when status in 400..499 ->
           case client_error(resp, config[:json_codec]) do
             {:retry, reason} ->
               request_and_retry(method, url, service, config, headers, req_body, attempt_again?(attempt, reason, config))
             {:error, reason} -> {:error, reason}
           end
-        {:ok, %{status_code: status, body: body}} when status >= 500 ->
+        {:ok, %{status_code: status} = resp} when status >= 500 ->
+          body = Map.get(resp, :body)
           reason = {:http_error, status, body}
           request_and_retry(method, url, service, config, headers, req_body, attempt_again?(attempt, reason, config))
         {:error, %{reason: reason}} ->

--- a/lib/ex_aws/request.ex
+++ b/lib/ex_aws/request.ex
@@ -26,7 +26,8 @@ defmodule ExAws.Request do
     request_and_retry(http_method, url, service, config, headers, body, {:attempt, 1})
   end
 
-  def request_and_retry(_method, _url, _service, _config, _headers, _req_body, {:error, reason}), do: {:error, reason}
+  def request_and_retry(_method, _url, _service, _config, _headers, _req_body, {:error, reason}),
+    do: {:error, reason}
 
   def request_and_retry(method, url, service, config, headers, req_body, {:attempt, attempt}) do
     full_headers = ExAws.Auth.headers(method, url, service, config, headers, req_body)
@@ -43,16 +44,22 @@ defmodule ExAws.Request do
       case config[:http_client].request(method, url, req_body, full_headers, Map.get(config, :http_opts, [])) do
         {:ok, %{status_code: status} = resp} when status in 200..299 or status == 304 ->
           {:ok, resp}
+
         {:ok, %{status_code: status} = resp} when status in 400..499 ->
           case client_error(resp, config[:json_codec]) do
             {:retry, reason} ->
+              Logger.warn("ExAws: HTTP ERROR: #{inspect(reason)}")
               request_and_retry(method, url, service, config, headers, req_body, attempt_again?(attempt, reason, config))
-            {:error, reason} -> {:error, reason}
+            {:error, reason} ->
+              {:error, reason}
           end
+
         {:ok, %{status_code: status} = resp} when status >= 500 ->
           body = Map.get(resp, :body)
           reason = {:http_error, status, body}
+          Logger.warn("ExAws: HTTP ERROR: #{inspect(reason)}")
           request_and_retry(method, url, service, config, headers, req_body, attempt_again?(attempt, reason, config))
+
         {:error, %{reason: reason}} ->
           Logger.warn("ExAws: HTTP ERROR: #{inspect reason}")
           request_and_retry(method, url, service, config, headers, req_body, attempt_again?(attempt, reason, config))
@@ -87,7 +94,7 @@ defmodule ExAws.Request do
     |> String.split("#")
     |> case do
       [_, type] -> type
-      type      -> type
+      [type]    -> type
     end
   end
 


### PR DESCRIPTION
Ensures that error types from AWS responses are parsed properly.

Closes https://github.com/ex-aws/ex_aws/issues/529