### PR TITLE
Rename kinesis.tail mix task to aws.kinesis.tail

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ ExAws can also be used directly without any specific service module.
 - Minimal dependencies. Choose your favorite JSON codec and HTTP client.
 - Elixir streams to automatically retrieve paginated resources.
 - Elixir protocols allow easy customization of Dynamo encoding / decoding.
-- `mix kinesis.tail your-stream-name` task for easily watching the contents of a kinesis stream.
+- `mix aws.kinesis.tail your-stream-name` task for easily watching the contents of a kinesis stream.
 - Simple. ExAws aims to provide a clear and consistent elixir wrapping around AWS APIs, not abstract them away entirely. For every action in a given AWS API there is a corresponding function within the appropriate module. Higher level abstractions like the aforementioned streams are in addition to and not instead of basic API calls.
 
 That's it!

--- a/lib/mix/tasks/tail.ex
+++ b/lib/mix/tasks/tail.ex
@@ -1,4 +1,4 @@
-defmodule Mix.Tasks.Kinesis.Tail do
+defmodule Mix.Tasks.Aws.Kinesis.Tail do
   use Mix.Task
 
   @shortdoc "tails a stream"
@@ -7,7 +7,7 @@ defmodule Mix.Tasks.Kinesis.Tail do
   Tails a Stream
 
   ## Usage
-      kinesis.tail [stream_name] [options]
+      aws.kinesis.tail [stream_name] [options]
 
   ## Options
       --poll N   Time in seconds between polling. Default: 5
@@ -15,8 +15,8 @@ defmodule Mix.Tasks.Kinesis.Tail do
       --from     Sequence number to start at. If unspecified, LATEST is used
 
   ## Examples
-      $mix kinesis.tail my-kinesis-stream
-      $mix kinesis.tail logs --debug --poll 10
+      $ mix aws.kinesis.tail my-kinesis-stream
+      $ mix aws.kinesis.tail logs --debug --poll 10
   """
 
   def run(_) do


### PR DESCRIPTION
This pull request prefixes the kinesis.tail mix task with `aws` in order to establish a common prefix for mix tasks of `ex_aws`.

For further reference see #528 