### PR TITLE
Change .to_existing_atom to .to_atom method for parse_ini_file

### DIFF
--- a/lib/ex_aws/credentials_ini.ex
+++ b/lib/ex_aws/credentials_ini.ex
@@ -33,7 +33,7 @@ if Code.ensure_loaded?(ConfigParser) do
         updated_key =
           key
           |> String.replace_leading("aws_", "")
-          |> String.to_existing_atom
+          |> String.to_atom
 
         {updated_key, val}
       end)


### PR DESCRIPTION
I am having an issue with this method, that always return an empty Map even when I have a `.aws/config` file present.

Given the following file:
```
[profile test]
source_profile=credential_name
role_arn=arn:aws:iam:::role/
mfa_serial=arn:aws:iam::::/
```

`ExAws.CredentialsIni.security_credentials("test")` will always return `%{}` when using `String.to_existing_atom`


Changing it to `String.to_atom` fixes the problem and the output is now:

```elixir
%{
    mfa_serial: "arn:aws:iam::::/",
    role_arn: "arn:aws:iam:::role/",
    source_profile: "credential_name"
}
```