### PR TITLE
Fix possible UndefinedFunctionError in ExAws.InstanceMeta.request/2

### DIFF
--- a/lib/ex_aws/instance_meta.ex
+++ b/lib/ex_aws/instance_meta.ex
@@ -12,7 +12,7 @@ defmodule ExAws.InstanceMeta do
   @task_role_root "http://169.254.170.2"
 
   def request(config, url) do
-    case config.http_client.request(:get, url) do
+    case config.http_client.request(:get, url, "", [], []) do
       {:ok, %{status_code: 200, body: body}} ->
         body
 

--- a/test/ex_aws/instance_meta_test.exs
+++ b/test/ex_aws/instance_meta_test.exs
@@ -1,0 +1,23 @@
+defmodule ExAws.InstanceMetaTest do
+  use ExUnit.Case, async: true
+
+  import Mox
+
+  test "instance_role" do
+    role_name = "dummy-role"
+
+    ExAws.Request.HttpMock
+    |> expect(:request, fn _method, _url, _body, _headers, _opts ->
+      {:ok, %{status_code: 200, body: role_name}}
+    end)
+
+    config =
+      ExAws.Config.new(:s3,
+        http_client: ExAws.Request.HttpMock,
+        access_key_id: "dummy",
+        secret_access_key: "dummy"
+      )
+
+    assert ExAws.InstanceMeta.instance_role(config) == role_name
+  end
+end


### PR DESCRIPTION
ExAws.Request.HttpClient behaviour specifies one callback function.

```elixir
  @callback request(
              method :: http_method,
              url :: binary,
              req_body :: binary,
              headers :: [{binary, binary}, ...],
              http_opts :: term
            ) ::
              {:ok, %{status_code: pos_integer, body: binary}}
              | {:error, %{reason: any}}
```

But in `ExAws.InstanceMeta.request/2`, it expects `HttpClient.reqeust/2`. So an UndefinedFunctionError will be occurred if a custom HttpClient module doesn't implement `request/2`.

```
** (UndefinedFunctionError) function MyHTTPClient.request/2 is undefined or private
(my_project) MyHTTPClient.request(:get, "http://169.254.169.254/latest/meta-data/iam/security-credentials/")
(ex_aws) lib/ex_aws/instance_meta.ex:16: ExAws.InstanceMeta.request/2
(ex_aws) lib/ex_aws/instance_meta.ex:58: ExAws.InstanceMeta.instance_role_credentials/1
(ex_aws) lib/ex_aws/instance_meta.ex:64: ExAws.InstanceMeta.security_credentials/1
(ex_aws) lib/ex_aws/config/auth_cache.ex:58: ExAws.Config.AuthCache.refresh_config/2
(ex_aws) lib/ex_aws/config/auth_cache.ex:33: ExAws.Config.AuthCache.handle_call/3
(stdlib) gen_server.erl:661: :gen_server.try_handle_call/4
(stdlib) gen_server.erl:690: :gen_server.handle_msg/6
```

This PR fixes the issue and add a simple test.
