### PR TITLE
Allow :region to be retrieved at runtime

### DIFF
--- a/lib/ex_aws/config.ex
+++ b/lib/ex_aws/config.ex
@@ -44,6 +44,8 @@ defmodule ExAws.Config do
       Map.get(overrides, :region) || Map.get(service_config, :region) ||
         Map.get(common_config, :region) || "us-east-1"
 
+    region = retrieve_runtime_value(region, service_config)
+
     defaults = ExAws.Config.Defaults.get(service, region)
 
     defaults

--- a/test/ex_aws/config_test.exs
+++ b/test/ex_aws/config_test.exs
@@ -7,15 +7,20 @@ defmodule ExAws.ConfigTest do
   end
 
   test "{:system} style configs work" do
-    value = "foo"
-    System.put_env("ExAwsConfigTest", value)
+    access_key_id = "foo"
+    region = "eu-central-1"
 
-    assert :s3
-           |> ExAws.Config.new(
-             access_key_id: {:system, "ExAwsConfigTest"},
-             secret_access_key: {:system, "AWS_SECURITY_TOKEN"}
-           )
-           |> Map.get(:access_key_id) == value
+    System.put_env("ExAwsConfigTest", access_key_id)
+    System.put_env("AWS_REGION", region)
+
+    config =
+      ExAws.Config.new(:s3,
+        access_key_id: {:system, "ExAwsConfigTest"},
+        secret_access_key: {:system, "AWS_SECURITY_TOKEN"},
+        region: {:system, "AWS_REGION"}
+      )
+
+    assert %{access_key_id: ^access_key_id, region: ^region} = config
   end
 
   test "security_token is configured properly" do


### PR DESCRIPTION
This will allow the value of `:region` to be retrieved at runtime when set using the `{:system}` and/or `{:awscli}` config styles:

``` elixir
config :ex_aws,
  # ...
  region: [
    {:system, "AWS_REGION"},
    {:awscli, "default", 30}
  ]
```