### PR TITLE
Defaults for SageMaker Runtime service

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,9 @@ As mentioned, ExAws is built around some common operations and thus the first st
 
 What this means is that we need every function within our hypothetical `ExAws.Redshift` module to return an `%ExAws.Operation.Query{}` struct.
 
+Note that the mapping from protocol to operation type isn't always one-to-one.
+For example, the `"rest-json"` protocol uses the `ExAws.Operation.JSON` type.
+
 ### Build a Project
 
 We now need to build a new project.

--- a/lib/ex_aws/config/defaults.ex
+++ b/lib/ex_aws/config/defaults.ex
@@ -60,6 +60,7 @@ defmodule ExAws.Config.Defaults do
   end
 
   defp service_map(:ses), do: "email"
+  defp service_map(:sagemaker_runtime), do: "runtime.sagemaker"
   defp service_map(:dynamodb_streams), do: "streams.dynamodb"
 
   defp service_map(service) do

--- a/lib/ex_aws/config/defaults.ex
+++ b/lib/ex_aws/config/defaults.ex
@@ -79,7 +79,7 @@ defmodule ExAws.Config.Defaults do
                     {partition["partition"], partition}
                   end)
 
-  def do_host(partition, service_slug, region) do
+  defp do_host(partition, service_slug, region) do
     partition = @partition_data |> Map.fetch!(partition)
     partition_name = partition["partition"]
 

--- a/lib/ex_aws/config/defaults.ex
+++ b/lib/ex_aws/config/defaults.ex
@@ -19,10 +19,13 @@ defmodule ExAws.Config.Defaults do
   Retrieve the default configuration for a service.
   """
   def defaults(:dynamodb_streams) do
-    %{
-      service_override: :dynamodb
-    }
+    %{service_override: :dynamodb}
     |> Map.merge(defaults(:dynamodb))
+  end
+
+  def defaults(:sagemaker_runtime) do
+    %{service_override: :sagemaker}
+    |> Map.merge(defaults(:sagemaker))
   end
 
   def defaults(_) do

--- a/priv/endpoints.exs
+++ b/priv/endpoints.exs
@@ -1066,6 +1066,7 @@
           }
         },
         "runtime.sagemaker" => %{
+          "defaults" => %{"credentialScope" => %{"service" => "sagemaker"}},
           "endpoints" => %{
             "ap-northeast-1" => %{},
             "eu-west-1" => %{},


### PR DESCRIPTION
Prepares ex_aws to be used with the SageMaker Runtime service.

It's one of those exceptional services - it's like a subservice of SageMaker.

- Adds an alias for the service name to make it easier to work with
- Override base defaults with `sagemaker` service defaults

Resolves https://github.com/ex-aws/ex_aws/issues/594