### PR TITLE
Accept sign_headers

### DIFF
--- a/lib/ex_aws/auth.ex
+++ b/lib/ex_aws/auth.ex
@@ -64,11 +64,12 @@ defmodule ExAws.Auth do
         config,
         expires,
         query_params \\ [],
+        sign_headers \\ [],
         body \\ nil
       ) do
     with {:ok, config} <- validate_config(config) do
       service = service_name(service)
-      signed_headers = presigned_url_headers(url, query_params)
+      signed_headers = presigned_url_headers(url, sign_headers)
 
       org_query_params = query_params |> Enum.map(fn {k, v} -> {to_string(k), v} end)
 


### PR DESCRIPTION
Issue: https://github.com/ex-aws/ex_aws/issues/602

Depends on: https://github.com/ex-aws/ex_aws_s3/pull/43

Accept `sign_headers` in addition to `query_params` to allow for query params that will not also be sent in the headers of the request.