### PR TITLE
Describe direct usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,64 @@ config :ex_aws,
 
 ExAws can also be used directly without any specific service module.
 
---TODO--
+You need to figure out how the API of the specific AWS service works, in particular:
+- Protocol (JSON or query).
+- Path (depends on the service and the specific operation, usually "/").
+- Service name (used to generate the request signature, [as described here](https://docs.aws.amazon.com/general/latest/gr/sigv4-create-string-to-sign.html)).
+- Request body, query params, HTTP method, and headers (depends on the service and specific operation).
+
+You can look for this information in the service's API reference at [docs.aws.amazon.com](https://docs.aws.amazon.com/index.html) or, for example, in the Go SDK API models at [github.com/aws/aws-sdk-go](https://github.com/aws/aws-sdk-go/tree/master/models/apis) (look for a `api-*.json` file).
+
+The protocol dictates which operation module to use for the request. If the protocol is JSON, use `ExAws.Operation.JSON`, if it's query, use `ExAws.Operation.Query`.
+
+### Examples
+
+#### Redshift DescribeClusters
+
+```elixir
+action = :describe_clusters
+action_string = action |> Atom.to_string |> Macro.camelize
+
+operation =
+  %ExAws.Operation.Query{
+    path: "/",
+    params: %{"Action" => action_string},
+    service: :redshift,
+    action: action
+  }
+  
+ExAws.request(operation)
+```
+
+#### ECS RunTask
+
+```elixir
+data = %{
+  taskDefinition: "hello_world",
+  launchType: "FARGATE",
+  networkConfiguration: %{
+    awsvpcConfiguration: %{
+      subnets: ["subnet-1a2b3c4d", "subnet-4d3c2b1a"],
+      securityGroups: ["sg-1a2b3c4d"],
+      assignPublicIp: "ENABLED"
+    }
+  }
+}
+
+operation =
+  %ExAws.Operation.JSON{
+    http_method: :post,
+    headers: [
+      {"x-amz-target", "AmazonEC2ContainerServiceV20141113.RunTask"},
+      {"content-type", "application/x-amz-json-1.1"}
+    ],
+    path: "/",
+    data: data,
+    service: :ecs
+}
+
+ExAws.request(operation)
+```
 
 ## Highlighted Features
 - Easy configuration.

--- a/lib/ex_aws/operation.ex
+++ b/lib/ex_aws/operation.ex
@@ -3,7 +3,7 @@ defprotocol ExAws.Operation do
   An operation to perform on AWS
 
   This module defines a protocol for executing operations on AWS. ExAws ships with
-  several different modules that each implement the ExAws.Operatinon protocol. These
+  several different modules that each implement the ExAws.Operation protocol. These
   modules each handle one of the broad categories of AWS service types:
 
   - `ExAws.Operation.JSON`
@@ -11,7 +11,7 @@ defprotocol ExAws.Operation do
   - `ExAws.Operation.RestQuery`
   - `ExAws.Operation.S3`
 
-  ExAws works by creating an datastructure that implements this protocol, and then
+  ExAws works by creating a data structure that implements this protocol, and then
   calling `perform/2` on it.
 
   ## Example
@@ -26,7 +26,7 @@ defprotocol ExAws.Operation do
     params: %{},
     path: "/",
     service: :dynamodb,
-  } |> ExAw
+  } |> ExAws.Operation.perform(ExAws.Config.new(:dynamodb))
   ```
   """
   def perform(operation, config)


### PR DESCRIPTION
I don't have much experience using the AWS HTTP API directly except for figuring out how to run an ECS task with this library, so I would appreciate a thorough review. The contributing guidelines about adding new service modules were quite helpful.

I found four different implementations of `ExAWS.Operation`: `JSON`, `Query`, `RestQuery`, and `S3`. The example of `JSON` is from my own app, the example of `Query` is from the contributing guidelines.

I didn't mention `S3` because there is a service module for S3.

I didnt' mention `RestQuery` because I do not know for which AWS service it could be used. In https://github.com/aws/aws-sdk-go/tree/master/models/apis (mentioned in the contributing guidelines), I only found protocols "query", "json", and "rest-json" - not "rest-query". If somebody gives me a hint about this, I will update the PR.

The PR also includes unrelated fixes of typos I found while reading the `ExAWS.Operation` module.
