### PR TITLE
Log error and details of the failed request

### DIFF
--- a/lib/ex_aws/request.ex
+++ b/lib/ex_aws/request.ex
@@ -32,9 +32,11 @@ defmodule ExAws.Request do
       safe_url = replace_spaces(url)
 
       if config[:debug_requests] do
-        Logger.debug("Request URL: #{inspect(safe_url)} ATTEMPT: #{attempt}")
-        Logger.debug("Request HEADERS: #{inspect(full_headers)}")
-        Logger.debug("Request BODY: #{inspect(req_body)}")
+        Logger.debug(
+          "ExAws: Request URL: #{inspect(safe_url)} HEADERS: #{inspect(full_headers)} BODY: #{
+            inspect(req_body)
+          } ATTEMPT: #{attempt}"
+        )
       end
 
       case config[:http_client].request(

--- a/lib/ex_aws/request.ex
+++ b/lib/ex_aws/request.ex
@@ -86,9 +86,7 @@ defmodule ExAws.Request do
 
         {:error, %{reason: reason}} ->
           Logger.warn(
-            "ExAws: HTTP ERROR: #{inspect(reason)} for URL: #{inspect(safe_url)} HEADERS: #{
-              inspect(full_headers)
-            } BODY: #{inspect(req_body)} ATTEMPT: #{attempt}"
+            "ExAws: HTTP ERROR: #{inspect(reason)} for URL: #{inspect(safe_url)} ATTEMPT: #{attempt}"
           )
 
           request_and_retry(

--- a/lib/ex_aws/request.ex
+++ b/lib/ex_aws/request.ex
@@ -83,7 +83,15 @@ defmodule ExAws.Request do
           )
 
         {:error, %{reason: reason}} ->
-          Logger.warn("ExAws: HTTP ERROR: #{inspect(reason)}")
+          if config[:debug_requests] do
+            Logger.warn(
+              "ExAws: HTTP ERROR: #{inspect(reason)} for URL: #{inspect(safe_url)} HEADERS: #{
+                inspect(full_headers)
+              } BODY: #{inspect(req_body)}"
+            )
+          else
+            Logger.warn("ExAws: HTTP ERROR: #{inspect(reason)}")
+          end
 
           request_and_retry(
             method,

--- a/lib/ex_aws/request.ex
+++ b/lib/ex_aws/request.ex
@@ -83,15 +83,11 @@ defmodule ExAws.Request do
           )
 
         {:error, %{reason: reason}} ->
-          if config[:debug_requests] do
-            Logger.warn(
-              "ExAws: HTTP ERROR: #{inspect(reason)} for URL: #{inspect(safe_url)} HEADERS: #{
-                inspect(full_headers)
-              } BODY: #{inspect(req_body)} ATTEMPT: #{attempt}"
-            )
-          else
-            Logger.warn("ExAws: HTTP ERROR: #{inspect(reason)}")
-          end
+          Logger.warn(
+            "ExAws: HTTP ERROR: #{inspect(reason)} for URL: #{inspect(safe_url)} HEADERS: #{
+              inspect(full_headers)
+            } BODY: #{inspect(req_body)} ATTEMPT: #{attempt}"
+          )
 
           request_and_retry(
             method,

--- a/lib/ex_aws/request.ex
+++ b/lib/ex_aws/request.ex
@@ -32,7 +32,7 @@ defmodule ExAws.Request do
       safe_url = replace_spaces(url)
 
       if config[:debug_requests] do
-        Logger.debug("Request URL: #{inspect(safe_url)}")
+        Logger.debug("Request URL: #{inspect(safe_url)} ATTEMPT: #{attempt}")
         Logger.debug("Request HEADERS: #{inspect(full_headers)}")
         Logger.debug("Request BODY: #{inspect(req_body)}")
       end
@@ -87,7 +87,7 @@ defmodule ExAws.Request do
             Logger.warn(
               "ExAws: HTTP ERROR: #{inspect(reason)} for URL: #{inspect(safe_url)} HEADERS: #{
                 inspect(full_headers)
-              } BODY: #{inspect(req_body)}"
+              } BODY: #{inspect(req_body)} ATTEMPT: #{attempt}"
             )
           else
             Logger.warn("ExAws: HTTP ERROR: #{inspect(reason)}")


### PR DESCRIPTION
Currently, ExAWS reports errors with `Logger.warn/2`, but we want to know what the request failed. So this PR adds request information if `config[:debug_requests]` enabled.