### PR TITLE
Add AWS Transcribe endpoints

### DIFF
--- a/priv/endpoints.exs
+++ b/priv/endpoints.exs
@@ -1795,6 +1795,16 @@
             "us-west-2" => %{}
           }
         },
+        "transcribe" => %{
+          "endpoints" => %{
+            "us-east-1" => %{},
+            "us-east-2" => %{},
+            "us-west-2" => %{},
+            "ap-southeast-2" => %{},
+            "ca-central-1" => %{},
+            "eu-west-1" => %{},
+          }
+        },
         "mediapackage" => %{
           "endpoints" => %{
             "ap-northeast-1" => %{},


### PR DESCRIPTION
Adds endpoints for the AWS Transcribe service based on [AWS Regions and Endpoints](https://docs.aws.amazon.com/general/latest/gr/rande.html#transcribe_region) page.

Works with [ex_aws_transcribe](https://hex.pm/packages/ex_aws_transcribe).
