### PR TITLE
Add a behaviour for the toplevel functions

### DIFF
--- a/lib/ex_aws.ex
+++ b/lib/ex_aws.ex
@@ -2,6 +2,8 @@ defmodule ExAws do
   @moduledoc File.read!("#{__DIR__}/../README.md")
   use Application
 
+  @behaviour ExAws.Behaviour
+
   @doc """
   Perform an AWS request
 
@@ -43,9 +45,7 @@ defmodule ExAws do
   ```
 
   """
-  @spec request(ExAws.Operation.t()) :: {:ok, term} | {:error, term}
-  @spec request(ExAws.Operation.t(), Keyword.t()) :: {:ok, term} | {:error, term}
-
+  @impl ExAws.Behaviour
   def request(op, config_overrides \\ []) do
     ExAws.Operation.perform(op, ExAws.Config.new(op.service, config_overrides))
   end
@@ -56,8 +56,7 @@ defmodule ExAws do
   Same as `request/1,2` except it will either return the successful response from
   AWS or raise an exception.
   """
-  @spec request!(ExAws.Operation.t()) :: term | no_return
-  @spec request!(ExAws.Operation.t(), Keyword.t()) :: term | no_return
+  @impl ExAws.Behaviour
   def request!(op, config_overrides \\ []) do
     case request(op, config_overrides) do
       {:ok, result} ->
@@ -80,13 +79,13 @@ defmodule ExAws do
   ExAws.S3.list_objects("my-bucket") |> ExAws.stream!
   ```
   """
-  @spec stream!(ExAws.Operation.t()) :: Enumerable.t()
-  @spec stream!(ExAws.Operation.t(), Keyword.t()) :: Enumerable.t()
+  @impl ExAws.Behaviour
   def stream!(op, config_overrides \\ []) do
     ExAws.Operation.stream!(op, ExAws.Config.new(op.service, config_overrides))
   end
 
   @doc false
+  @impl Application
   def start(_type, _args) do
     import Supervisor.Spec, warn: false
 

--- a/lib/ex_aws/behaviour.ex
+++ b/lib/ex_aws/behaviour.ex
@@ -1,0 +1,14 @@
+defmodule ExAws.Behaviour do
+  @moduledoc """
+  A behaviour definition for the core operations of ExAws
+  """
+
+  @callback request(ExAws.Operation.t()) :: {:ok, term} | {:error, term}
+  @callback request(ExAws.Operation.t(), Keyword.t()) :: {:ok, term} | {:error, term}
+
+  @callback request!(ExAws.Operation.t()) :: term | no_return
+  @callback request!(ExAws.Operation.t(), Keyword.t()) :: term | no_return
+
+  @callback stream!(ExAws.Operation.t()) :: Enumerable.t()
+  @callback stream!(ExAws.Operation.t(), Keyword.t()) :: Enumerable.t()
+end


### PR DESCRIPTION
I found [this discussion](https://github.com/ex-aws/ex_aws_s3/issues/27) in the s3 repo, but it looks like nothing ever came of it. I think it's pretty important to be able to Mox pretty much anything that one would do with s3 for testing. Thanks to how you've set up the library, it's such a small change to make that possible!