### PR TITLE
exponential backoff for InstanceMeta rate limit

### DIFF
--- a/test/ex_aws/instance_meta_test.exs
+++ b/test/ex_aws/instance_meta_test.exs
@@ -1,5 +1,5 @@
 defmodule ExAws.InstanceMetaTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
 
   import Mox
 
@@ -19,5 +19,48 @@ defmodule ExAws.InstanceMetaTest do
       )
 
     assert ExAws.InstanceMeta.instance_role(config) == role_name
+  end
+
+  test "retry after a 429" do
+    ExAws.Request.HttpMock
+    |> expect(:request, fn _method, _url, _body, _headers, _opts ->
+      {:ok, %{status_code: 429, body: ""}}
+    end)
+    |> expect(:request, fn _method, _url, _body, _headers, _opts ->
+      {:ok, %{status_code: 200, body: "body"}}
+    end)
+
+    config =
+      ExAws.Config.new(:s3,
+        http_client: ExAws.Request.HttpMock,
+        access_key_id: "dummy",
+        secret_access_key: "dummy"
+      )
+
+    assert ExAws.InstanceMeta.request(config, "url") == "body"
+  end
+
+  test "fails after too many 429s" do
+    old_config = Application.get_env(:ex_aws, :retries) || []
+    Application.put_env(:ex_aws, :retries, Keyword.put(old_config, :max_attempts, 0))
+    on_exit fn ->
+      Application.put_env(:ex_aws, :retries, old_config)
+    end
+
+    ExAws.Request.HttpMock
+    |> expect(:request, fn _method, _url, _body, _headers, _opts ->
+      {:ok, %{status_code: 429, body: ""}}
+    end)
+
+    config =
+      ExAws.Config.new(:s3,
+        http_client: ExAws.Request.HttpMock,
+        access_key_id: "dummy",
+        secret_access_key: "dummy"
+      )
+
+    assert_raise RuntimeError, fn ->
+      ExAws.InstanceMeta.request(config, "url")
+    end
   end
 end


### PR DESCRIPTION
Periodically, our ECS instances will crash with the following error:
```
** (RuntimeError) Instance Meta Error: HTTP response status code 429

Please check AWS EC2 IAM role.
```

The roles are fine, but something has made too many requests to the instance metadata endpoint. This PR re-uses the retry logic from ExAws.Request to retry these InstanceMeta requests as well.
