### PR TITLE
add support for lex models and runtime on service overrides

### DIFF
--- a/lib/ex_aws/config/defaults.ex
+++ b/lib/ex_aws/config/defaults.ex
@@ -23,6 +23,16 @@ defmodule ExAws.Config.Defaults do
     |> Map.merge(defaults(:dynamodb))
   end
 
+  def defaults(:lex_runtime) do
+    %{service_override: :lex}
+    |> Map.merge(defaults(:lex))
+  end
+
+  def defaults(:lex_models) do
+    %{service_override: :lex}
+    |> Map.merge(defaults(:lex))
+  end
+
   def defaults(:sagemaker_runtime) do
     %{service_override: :sagemaker}
     |> Map.merge(defaults(:sagemaker))
@@ -69,6 +79,8 @@ defmodule ExAws.Config.Defaults do
 
   defp service_map(:ses), do: "email"
   defp service_map(:sagemaker_runtime), do: "runtime.sagemaker"
+  defp service_map(:lex_runtime), do: "runtime.lex"
+  defp service_map(:lex_models), do: "models.lex"
   defp service_map(:dynamodb_streams), do: "streams.dynamodb"
   defp service_map(:iot_data), do: "data.iot"
 


### PR DESCRIPTION
I am working on lex runtime and models services for ex_aws. `models.lex` or `runtime.lex` is prefixed in url and `lex` is used in credential scope. It would nice to get it in the ex_aws.

Also, are we doing any new releases for changes like these? Looks like sagemaker change like this is not in the hex yet.