### PR TITLE
Support reading the profile from env variable

### DIFF
--- a/lib/ex_aws/credentials_ini.ex
+++ b/lib/ex_aws/credentials_ini.ex
@@ -6,14 +6,14 @@ if Code.ensure_loaded?(ConfigParser) do
       role_arn source_profile credential_source external_id mfa_serial role_session_name
     )
 
-    def security_credentials(:system) do
-      security_credentials(System.get_env("AWS_PROFILE"))
-    end
-
     def security_credentials(profile_name) do
       shared_credentials = profile_from_shared_credentials(profile_name)
       config_credentials = profile_from_config(profile_name)
       Map.merge(config_credentials, shared_credentials)
+    end
+
+    def parse_ini_file({:ok, contents}, :system) do
+      parse_ini_file({:ok, contents}, profile_name_from_env())
     end
 
     def parse_ini_file({:ok, contents}, profile_name) do
@@ -67,6 +67,7 @@ if Code.ensure_loaded?(ConfigParser) do
     defp profile_from_config(profile_name) do
       section =
         case profile_name do
+          :system -> "profile #{profile_name_from_env()}"
           "default" -> "default"
           other -> "profile #{other}"
         end
@@ -75,6 +76,10 @@ if Code.ensure_loaded?(ConfigParser) do
       |> Path.join(".aws/config")
       |> File.read()
       |> parse_ini_file(section)
+    end
+
+    defp profile_name_from_env() do
+      System.get_env("AWS_PROFILE") || "default"
     end
   end
 else

--- a/lib/ex_aws/credentials_ini.ex
+++ b/lib/ex_aws/credentials_ini.ex
@@ -6,6 +6,10 @@ if Code.ensure_loaded?(ConfigParser) do
       role_arn source_profile credential_source external_id mfa_serial role_session_name
     )
 
+    def security_credentials(:system) do
+      security_credentials(System.get_env("AWS_PROFILE"))
+    end
+
     def security_credentials(profile_name) do
       shared_credentials = profile_from_shared_credentials(profile_name)
       config_credentials = profile_from_config(profile_name)

--- a/test/ex_aws/config_test.exs
+++ b/test/ex_aws/config_test.exs
@@ -46,6 +46,28 @@ defmodule ExAws.ConfigTest do
     assert credentials.secret_access_key == "TESTSECRET"
     assert credentials.security_token == "TESTTOKEN"
   end
+  
+  test "{:system} in profile name gets dynamic profile name" do
+    System.put_env("AWS_PROFILE", "custom-profile")
+
+    example_credentials = """
+    [custom-profile]
+    aws_access_key_id     = TESTKEYID
+    aws_secret_access_key = TESTSECRET
+    aws_session_token     = TESTTOKEN
+    """
+
+    assert :s3
+           |> ExAws.Config.new(
+             access_key_id: [{:awscli, :system, 30}],
+             secret_access_key: [{:awscli, :system, 30}]
+           )
+           |> (fn 
+             %{access_key_id: "TESTKEYID", secret_access_key: "TESTSECRET", security_token: "TESTTOKEN"} -> true
+             _ -> false
+           end).()
+  end
+
 
   test "config file is parsed" do
     example_config = """

--- a/test/ex_aws/config_test.exs
+++ b/test/ex_aws/config_test.exs
@@ -46,7 +46,7 @@ defmodule ExAws.ConfigTest do
     assert credentials.secret_access_key == "TESTSECRET"
     assert credentials.security_token == "TESTTOKEN"
   end
-  
+
   test "{:system} in profile name gets dynamic profile name" do
     System.put_env("AWS_PROFILE", "custom-profile")
 
@@ -57,17 +57,14 @@ defmodule ExAws.ConfigTest do
     aws_session_token     = TESTTOKEN
     """
 
-    assert :s3
-           |> ExAws.Config.new(
-             access_key_id: [{:awscli, :system, 30}],
-             secret_access_key: [{:awscli, :system, 30}]
-           )
-           |> (fn 
-             %{access_key_id: "TESTKEYID", secret_access_key: "TESTSECRET", security_token: "TESTTOKEN"} -> true
-             _ -> false
-           end).()
-  end
+    credentials =
+      ExAws.CredentialsIni.parse_ini_file({:ok, example_credentials}, :system)
+      |> ExAws.CredentialsIni.replace_token_key()
 
+    assert credentials.access_key_id == "TESTKEYID"
+    assert credentials.secret_access_key == "TESTSECRET"
+    assert credentials.security_token == "TESTTOKEN"
+  end
 
   test "config file is parsed" do
     example_config = """


### PR DESCRIPTION
`aws-cli` supports choosing the profile from the AWS_PROFILE variable. With this change the profile will be resolved on runtime so the same build can be executed with any local profile.

Old config (hardcoded profile name):
```ex
config :ex_aws,
  access_key_id: [{:system, "AWS_ACCESS_KEY_ID"}, {:awscli, "default", 30}, :instance_role]
```

dynamic profile selection (from env):
```ex
config :ex_aws,
  access_key_id: [{:system, "AWS_ACCESS_KEY_ID"}, {:awscli, :system, 30}, :instance_role]
```
