### PR TITLE
Update HttpClient example to follow @callback

### DIFF
--- a/lib/ex_aws/request/http_client.ex
+++ b/lib/ex_aws/request/http_client.ex
@@ -20,11 +20,21 @@ defmodule ExAws.Request.HttpClient do
   ```elixir
   defmodule ExAws.Request.HTTPotion do
     @behaviour ExAws.Request.HttpClient
-    def request(method, url, body, headers) do
+    def request(method, url, body, headers, http_opts) do
       {:ok, HTTPotion.request(method, url, [body: body, headers: headers, ibrowse: [headers_as_is: true]])}
     end
   end
   ```
+
+  When conforming your selected HTTP Client take note of a few things:
+    - The module name doesn't need to follow the same styling as this module it is simply your own 'HTTP Client', i.e. #{project_name}.HttpClient
+    - The request function must accept the methods as described in the @callback below, you can however set these as optional, i.e. (http_opts \\ [])
+    - Ensure the call to your chosen HTTP Client is correct and the return is in the same format as defined in the @callback below, for example:
+      ```elixir
+          def request(method, url, body, headers, http_opts \\ []) do
+            Mojito.request(method, url, headers, body, http_opts)
+          end
+      ```
   """
 
   @type http_method :: :get | :post | :put | :delete


### PR DESCRIPTION
The HttpClient example was misleading not only for me but I can see in the Issues another user, it led users of ExAws to believe 
that ExAws.Request.HttpClient.request/5 only took /4. Have also added
some extra description to help with the conforming of the Client.request
firing to give a bit more clarity.