### PR TITLE
Allow turning off normalize_path

### DIFF
--- a/lib/ex_aws/config.ex
+++ b/lib/ex_aws/config.ex
@@ -14,7 +14,8 @@ defmodule ExAws.Config do
     :debug_requests,
     :region,
     :security_token,
-    :retries
+    :retries,
+    :normalize_path
   ]
 
   @type t :: %{} | Keyword.t()

--- a/lib/ex_aws/config/defaults.ex
+++ b/lib/ex_aws/config/defaults.ex
@@ -12,7 +12,8 @@ defmodule ExAws.Config.Defaults do
       max_attempts: 10,
       base_backoff_in_ms: 10,
       max_backoff_in_ms: 10_000
-    ]
+    ],
+    normalize_path: true
   }
 
   @doc """

--- a/lib/ex_aws/request/url.ex
+++ b/lib/ex_aws/request/url.ex
@@ -10,7 +10,7 @@ defmodule ExAws.Request.Url do
     |> Map.put(:query, query(operation))
     |> Map.put(:path, operation.path)
     |> normalize_scheme
-    |> normalize_path
+    |> normalize_path(config.normalize_path)
     |> convert_port_to_integer
     |> (&struct(URI, &1)).()
     |> URI.to_string()
@@ -28,7 +28,8 @@ defmodule ExAws.Request.Url do
     url |> Map.update(:scheme, "", &String.replace(&1, "://", ""))
   end
 
-  defp normalize_path(url) do
+  defp normalize_path(url, false), do: url
+  defp normalize_path(url, _normalize) do
     url |> Map.update(:path, "", &String.replace(&1, ~r/\/{2,}/, "/"))
   end
 

--- a/test/ex_aws/request/url_test.exs
+++ b/test/ex_aws/request/url_test.exs
@@ -11,7 +11,8 @@ defmodule ExAws.Request.UrlTest do
     config = %{
       scheme: "https",
       host: "example.com",
-      port: 443
+      port: 443,
+      normalize_path: true
     }
 
     {:ok, %{query: query, config: config}}


### PR DESCRIPTION
Very old s3 objects can have a leading forward slash and normalizing makes those objects inaccessible. Fixes https://github.com/ex-aws/ex_aws_s3/issues/58