### PR TITLE
Allow setting http_opts for use with HTTPotion instead of hackney

### DIFF
--- a/lib/ex_aws/config.ex
+++ b/lib/ex_aws/config.ex
@@ -8,6 +8,7 @@ defmodule ExAws.Config do
 
   @common_config [
     :http_client,
+    :http_opts,
     :json_codec,
     :access_key_id,
     :secret_access_key,

--- a/lib/ex_aws/request/http_client.ex
+++ b/lib/ex_aws/request/http_client.ex
@@ -21,7 +21,7 @@ defmodule ExAws.Request.HttpClient do
   defmodule ExAws.Request.HTTPotion do
     @behaviour ExAws.Request.HttpClient
     def request(method, url, body, headers, http_opts) do
-      {:ok, HTTPotion.request(method, url, [body: body, headers: headers, ibrowse: [headers_as_is: true]])}
+      {:ok, HTTPotion.request(method, url, [body: body, headers: headers, ibrowse: [{:headers_as_is, true} | http_opts]])}
     end
   end
   ```


### PR DESCRIPTION
The example in the documentation does not use the `http_opts` and since it is not part of the common config it is not picked up when set in config.