### PR TITLE
S3: Do not include content-length in GET headers.

### DIFF
--- a/lib/ex_aws/operation/s3.ex
+++ b/lib/ex_aws/operation/s3.ex
@@ -33,11 +33,17 @@ defmodule ExAws.Operation.S3 do
       headers =
         headers
         |> Map.put("x-amz-content-sha256", hashed_payload)
-        |> Map.put("content-length", byte_size(body))
+        |> put_content_length_header(body, http_method)
         |> Map.to_list()
 
       ExAws.Request.request(http_method, url, body, headers, config, operation.service)
       |> operation.parser.()
+    end
+
+    defp put_content_length_header(headers, "", :get), do: headers
+
+    defp put_content_length_header(headers, body, _) do
+      Map.put(headers, "content-length", byte_size(body))
     end
 
     def stream!(%{stream_builder: fun}, config) do


### PR DESCRIPTION
Hello ExAws devs,

for a project of ours we're working with a German cloud provider who offer S3 services. We ran into an issue with the `get_object/3` operation (likely all `get_*` operations, but we didn't test others) that responds with an `InvalidAccessKeyId` error, while `put_object/3` and friends are working fine. Retrieving objects using [s3cmd](https://s3tools.org/s3cmd) and even curl worked fine, though, so we suspected the problem to originate within ExAws.

After some debugging, we found out that ExAws is including `Content-Length: 0` in the request headers as well as the `Signed-Headers` in the AWS signature for all requests. Removing this header for empty `GET` requests fixes the issue.

While this is likely to be a quirky detail of whatever S3 implementation our hoster is running (and we're talking to them in parallel to ask whether they can fix it there), we thought the fix is simple enough to ask for inclusion in ExAws. Plus, the [S3 specification](https://docs.aws.amazon.com/AmazonS3/latest/API/RESTCommonRequestHeaders.html) states the header is optional for anything non-`PUT`, so it should theoretically work with compliant implementations. However, we haven't run tests against Amazon S3 or others yet.

Long story short, feel free to ignore & close this, we might be able to fix it in collaboration with the S3 provider. Though if you would consider this patch for inclusion, we'd be more than happy to finalize the implementation & add some tests.

cheers,
malte