### PR TITLE
Fix the json_codec decode method reference when there is a client error

### DIFF
--- a/lib/ex_aws/request.ex
+++ b/lib/ex_aws/request.ex
@@ -105,7 +105,7 @@ defmodule ExAws.Request do
   end
 
   def client_error(%{status_code: status, body: body} = error, json_codec) do
-    case json_codec.decode(body) do
+    case json_codec.decode!(body) do
       {:ok, %{"__type" => error_type, "message" => message} = err} ->
         error_type
         |> String.split("#")


### PR DESCRIPTION
The other places in this codebase use "decode!" but in the `client_error` method of request it calls `decode` which seems to not exist.

```
** (UndefinedFunctionError) function Eljiffy.decode/1 is undefined or private
        (eljiffy) Eljiffy.decode("{\"Message\":\"...\"}")
```

This PR changes the method to be the same as the others and calls `decode!`.