### PR TITLE
enable system envar spec for region config

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,13 @@ You can set the region used by default for requests.
 config :ex_aws,
   region: "us-west-2",
 ```
+Alternatively, the region can be set in an environment variable:
+
+```elixir
+config :ex_aws,
+  region: {:system, "AWS_REGION"}
+```
+
 
 ## Direct Usage
 

--- a/lib/ex_aws/config.ex
+++ b/lib/ex_aws/config.ex
@@ -41,8 +41,11 @@ defmodule ExAws.Config do
     service_config = Application.get_env(:ex_aws, service, []) |> Map.new()
 
     region =
-      Map.get(overrides, :region) || Map.get(service_config, :region) ||
-        Map.get(common_config, :region) || "us-east-1"
+      (Map.get(overrides, :region)
+        || Map.get(service_config, :region)
+        || Map.get(common_config, :region)
+        || "us-east-1")
+      |> retrieve_runtime_value(%{})
 
     defaults = ExAws.Config.Defaults.get(service, region)
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ExAws.Mixfile do
   use Mix.Project
 
-  @version "2.1.1"
+  @version "2.1.2"
 
   def project do
     [

--- a/test/ex_aws/config_test.exs
+++ b/test/ex_aws/config_test.exs
@@ -57,4 +57,22 @@ defmodule ExAws.ConfigTest do
 
     assert config.region == "eu-west-1"
   end
+
+  test "region as a plain string" do
+    region_value = "us-west-1"
+
+    assert :s3
+           |> ExAws.Config.new(region: region_value)
+           |> Map.get(:region) == region_value
+
+  end
+
+  test "region as an envar" do
+    region_value = "us-west-1"
+    System.put_env("AWS_REGION", region_value)
+
+    assert :s3
+           |> ExAws.Config.new(region: {:system, "AWS_REGION"})
+           |> Map.get(:region) == region_value
+  end
 end


### PR DESCRIPTION
This PR enables the use of an envar `AWS_REGION` to externally control the region configurations of `ex_aws`  usage.  

The PR provides:
- a simple change to the code that determines the region
- two new tests to confirm that plain-text and system envar configurations both work as expected.