### PR TITLE
Fix URL encoding for S3 objects with special characters

### DIFF
--- a/lib/ex_aws/auth.ex
+++ b/lib/ex_aws/auth.ex
@@ -87,17 +87,18 @@ defmodule ExAws.Auth do
 
       uri = URI.parse(url)
 
+      path = url |> Url.get_path(service) |> Url.uri_encode
       path =
         if uri.query do
-          uri.path <> "?" <> uri.query
+          path <> "?" <> uri.query
         else
-          uri.path
+          path
         end
 
       signature =
         signature(
           http_method,
-          path,
+          url,
           query_to_sign,
           signed_headers,
           body,

--- a/lib/ex_aws/auth.ex
+++ b/lib/ex_aws/auth.ex
@@ -3,6 +3,7 @@ defmodule ExAws.Auth do
 
   alias ExAws.Auth.Credentials
   alias ExAws.Auth.Signatures
+  alias ExAws.Request.Url
 
   @moduledoc false
 
@@ -139,7 +140,7 @@ defmodule ExAws.Auth do
   end
 
   defp signature(http_method, url, query, headers, body, service, datetime, config) do
-    path = url |> get_path() |> uri_encode()
+    path = url |> Url.get_path(service) |> Url.uri_encode()
     request = build_canonical_request(http_method, path, query, headers, body)
     string_to_sign = string_to_sign(request, service, datetime, config)
     Signatures.generate_signature_v4(service, config, datetime, string_to_sign)

--- a/lib/ex_aws/auth/utils.ex
+++ b/lib/ex_aws/auth/utils.ex
@@ -1,35 +1,6 @@
 defmodule ExAws.Auth.Utils do
   @moduledoc false
 
-  def uri_encode(url) do
-    url
-    |> String.replace("+", " ")
-    |> URI.encode(&valid_path_char?/1)
-  end
-
-  def get_path(url) do
-    base =
-      url
-      |> URI.parse()
-      |> Map.put(:path, nil)
-      |> Map.put(:fragment, nil)
-      |> URI.to_string()
-      |> URI.parse()
-      |> URI.to_string()
-
-    url
-    |> String.split(base, parts: 2)
-    |> List.last()
-  end
-
-  # Space character
-  def valid_path_char?(?\ ), do: false
-  def valid_path_char?(?/), do: true
-
-  def valid_path_char?(c) do
-    URI.char_unescaped?(c) && !URI.char_reserved?(c)
-  end
-
   def hash_sha256(data) do
     :sha256
     |> :crypto.hash(data)

--- a/lib/ex_aws/auth/utils.ex
+++ b/lib/ex_aws/auth/utils.ex
@@ -7,6 +7,21 @@ defmodule ExAws.Auth.Utils do
     |> URI.encode(&valid_path_char?/1)
   end
 
+  def get_path(url) do
+    base =
+      url
+      |> URI.parse()
+      |> Map.put(:path, nil)
+      |> Map.put(:fragment, nil)
+      |> URI.to_string()
+      |> URI.parse()
+      |> URI.to_string()
+
+    url
+    |> String.split(base, parts: 2)
+    |> List.last()
+  end
+
   # Space character
   def valid_path_char?(?\ ), do: false
   def valid_path_char?(?/), do: true

--- a/lib/ex_aws/auth/utils.ex
+++ b/lib/ex_aws/auth/utils.ex
@@ -1,6 +1,8 @@
 defmodule ExAws.Auth.Utils do
   @moduledoc false
 
+  def uri_encode(url), do: ExAws.Request.Url.uri_encode(url)
+
   def hash_sha256(data) do
     :sha256
     |> :crypto.hash(data)

--- a/lib/ex_aws/request.ex
+++ b/lib/ex_aws/request.ex
@@ -29,7 +29,7 @@ defmodule ExAws.Request do
     full_headers = ExAws.Auth.headers(method, url, service, config, headers, req_body)
 
     with {:ok, full_headers} <- full_headers do
-      safe_url = sanitize(url)
+      safe_url = __MODULE__.Url.sanitize(url, service)
 
       if config[:debug_requests] do
         Logger.debug(
@@ -150,13 +150,5 @@ defmodule ExAws.Request do
     |> trunc
     |> :rand.uniform()
     |> :timer.sleep()
-  end
-
-  defp sanitize(url) do
-    new_path = url |> ExAws.Auth.Utils.get_path() |> String.replace_prefix("/", "") |> URI.encode_www_form()
-
-    %{URI.parse(url) | fragment: nil, path: "/" <> new_path}
-    |> URI.to_string()
-    |> String.replace("+", "%20")
   end
 end

--- a/lib/ex_aws/request.ex
+++ b/lib/ex_aws/request.ex
@@ -29,7 +29,7 @@ defmodule ExAws.Request do
     full_headers = ExAws.Auth.headers(method, url, service, config, headers, req_body)
 
     with {:ok, full_headers} <- full_headers do
-      safe_url = replace_spaces(url)
+      safe_url = sanitize(url)
 
       if config[:debug_requests] do
         Logger.debug(
@@ -152,7 +152,11 @@ defmodule ExAws.Request do
     |> :timer.sleep()
   end
 
-  defp replace_spaces(url) do
-    String.replace(url, " ", "%20")
+  defp sanitize(url) do
+    new_path = url |> ExAws.Auth.Utils.get_path() |> String.replace_prefix("/", "") |> URI.encode_www_form()
+
+    %{URI.parse(url) | fragment: nil, path: "/" <> new_path}
+    |> URI.to_string()
+    |> String.replace("+", "%20")
   end
 end

--- a/lib/ex_aws/request.ex
+++ b/lib/ex_aws/request.ex
@@ -29,7 +29,7 @@ defmodule ExAws.Request do
     full_headers = ExAws.Auth.headers(method, url, service, config, headers, req_body)
 
     with {:ok, full_headers} <- full_headers do
-      safe_url = __MODULE__.Url.sanitize(url, service)
+      safe_url = ExAws.Request.Url.sanitize(url, service)
 
       if config[:debug_requests] do
         Logger.debug(

--- a/lib/ex_aws/request/url.ex
+++ b/lib/ex_aws/request/url.ex
@@ -75,16 +75,16 @@ defmodule ExAws.Request.Url do
   # as a fragment. This is correct, but S3 treats it as part
   # of the path of the object.
   #
-  # This will split the URL based on the base with the right
-  # side being the path, except for the query params.
+  # This will split the URL at the base with the right side
+  # being the path, except for the query params.
   #
   # for example:
-  # "https://bucket.aws.com/my/path/here+ #3.txt?t=21"
+  # `"https://bucket.aws.com/my/path/here+ #3.txt?t=21"`
   # https://bucket.aws.com | /my/path/here+ #3.txt?t=21
   # ________base__________ | /my/path/here+ #3.txt | t=21
   # ________base__________ | /my/path/here+ #3.txt | _params_
   #
-  # This ends up being URI encoded to /my/path/here%2B%20%233.txt
+  # After using `uri_encode` it will be `/my/path/here%2B%20%233.txt`
   #
   def get_path(url, service) when service in ["s3", :s3] do
     base =

--- a/lib/ex_aws/utils.ex
+++ b/lib/ex_aws/utils.ex
@@ -119,7 +119,6 @@ defmodule ExAws.Utils do
   end
 
   defp xml_format([nested | _] = params, prefix: pre, spec: spec) when is_list(nested) do
-    # IO.inspect("nested")
     params
     |> Stream.with_index(1)
     |> Stream.map(fn {params, i} -> {params, Integer.to_string(i)} end)
@@ -130,7 +129,6 @@ defmodule ExAws.Utils do
   end
 
   defp xml_format([param | _] = params, prefix: pre, spec: spec) when is_tuple(param) do
-    # IO.inspect("prefixed")
     params
     |> Stream.map(fn {key, values} -> {maybe_camelize(key, spec: spec), values} end)
     |> Stream.flat_map(fn {key, values} ->
@@ -141,7 +139,6 @@ defmodule ExAws.Utils do
 
   # Non-indexed formats
   defp xml_format(params, kwargs) when is_list(params) do
-    # IO.inspect("values")
     pre = kwargs[:prefix]
 
     params

--- a/test/ex_aws/auth_test.exs
+++ b/test/ex_aws/auth_test.exs
@@ -47,6 +47,26 @@ defmodule ExAws.AuthTest do
     assert {:ok, expected} == actual
   end
 
+  test "presigned url with special characters" do
+    http_method = :get
+    url = "https://examplebucket.s3.amazonaws.com/folder-one/test+ #3.txt"
+    service = :s3
+    datetime = {{2013, 5, 24}, {0, 0, 0}}
+    expires = 86400
+    actual = ExAws.Auth.presigned_url(http_method, url, service, datetime, @config, expires)
+
+    expected =
+      "https://examplebucket.s3.amazonaws.com/folder-one/test%2B%20%233.txt" <>
+        "?X-Amz-Algorithm=AWS4-HMAC-SHA256" <>
+        "&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20130524%2Fus-east-1%2Fs3%2Faws4_request" <>
+        "&X-Amz-Date=20130524T000000Z" <>
+        "&X-Amz-Expires=86400" <>
+        "&X-Amz-SignedHeaders=host" <>
+        "&X-Amz-Signature=d1892eeaf3110a6c1a805d8ad7a0c825a72a4255c7f48908922be55a7c4ae753"
+
+    assert {:ok, expected} == actual
+  end
+
   test "presigned url with query params" do
     # Data taken from example in:
     # http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html

--- a/test/ex_aws/auth_test.exs
+++ b/test/ex_aws/auth_test.exs
@@ -6,7 +6,7 @@ defmodule ExAws.AuthTest do
       build_canonical_request: 5
     ]
 
-  import ExAws.Auth.Utils,
+  import ExAws.Request.Url,
     only: [
       uri_encode: 1
     ]

--- a/test/ex_aws/request/url_test.exs
+++ b/test/ex_aws/request/url_test.exs
@@ -70,4 +70,16 @@ defmodule ExAws.Request.UrlTest do
     query = query |> Map.put(:params, %{"foo" => "bar", nil => 1})
     assert Url.build(query, config) == "https://example.com/path?foo=bar"
   end
+
+  describe "get_path" do
+    test "it uses S3-specific URL parsing to keep the path for S3 services" do
+      url = "https://example.com/uploads/invalid path but+valid//for#s3/haha.txt"
+      assert Url.get_path(url, :s3) == "/uploads/invalid path but+valid//for#s3/haha.txt"
+    end
+
+    test "it uses standard URL parsing for the path for non-S3 services" do
+      url = "https://example.com/uploads/invalid path but+valid//for#i-am-anchor"
+      assert Url.get_path(url) == "/uploads/invalid path but+valid//for"
+    end
+  end
 end

--- a/test/ex_aws/request_test.exs
+++ b/test/ex_aws/request_test.exs
@@ -46,13 +46,13 @@ defmodule ExAws.RequestTest do
       ExAws.Request.HttpMock,
       :request,
       fn _method, url, _body, _headers, _opts ->
-        assert url == "https://examplebucket.s3.amazonaws.com/test%20hello%20%233.txt"
+        assert url == "https://examplebucket.s3.amazonaws.com/test%20hello%20%233.txt?t=21"
         {:ok, %{status_code: 200}}
       end
     )
 
     http_method = :get
-    url = "https://examplebucket.s3.amazonaws.com/test hello #3.txt"
+    url = "https://examplebucket.s3.amazonaws.com/test hello #3.txt?t=21"
     service = :s3
     request_body = ""
 

--- a/test/ex_aws/request_test.exs
+++ b/test/ex_aws/request_test.exs
@@ -1,5 +1,6 @@
 defmodule ExAws.RequestTest do
   use ExUnit.Case, async: false
+  import ExUnit.CaptureLog
   import Mox
 
   setup do
@@ -26,16 +27,18 @@ defmodule ExAws.RequestTest do
     service = :s3
     request_body = ""
 
-    assert {:error, {:http_error, 301, "redirected"}} ==
-             ExAws.Request.request_and_retry(
-               http_method,
-               url,
-               service,
-               context[:config],
-               context[:headers],
-               request_body,
-               {:attempt, 1}
-             )
+    assert capture_log(fn ->
+      assert {:error, {:http_error, 301, "redirected"}} ==
+              ExAws.Request.request_and_retry(
+                http_method,
+                url,
+                service,
+                context[:config],
+                context[:headers],
+                request_body,
+                {:attempt, 1}
+              )
+    end) =~ "Received redirect, did you specify the correct region?"
   end
 
   test "handles encoding S3 URLs", context do

--- a/test/ex_aws/request_test.exs
+++ b/test/ex_aws/request_test.exs
@@ -37,4 +37,31 @@ defmodule ExAws.RequestTest do
                {:attempt, 1}
              )
   end
+
+  test "handles encoding S3 URLs", context do
+    expect(
+      ExAws.Request.HttpMock,
+      :request,
+      fn _method, url, _body, _headers, _opts ->
+        assert url == "https://examplebucket.s3.amazonaws.com/test%20hello%20%233.txt"
+        {:ok, %{status_code: 200}}
+      end
+    )
+
+    http_method = :get
+    url = "https://examplebucket.s3.amazonaws.com/test hello #3.txt"
+    service = :s3
+    request_body = ""
+
+    assert {:ok, %{status_code: 200}} ==
+             ExAws.Request.request_and_retry(
+               http_method,
+               url,
+               service,
+               context[:config],
+               context[:headers],
+               request_body,
+               {:attempt, 1}
+             )
+  end
 end

--- a/test/ex_aws/request_test.exs
+++ b/test/ex_aws/request_test.exs
@@ -70,7 +70,7 @@ defmodule ExAws.RequestTest do
 
   test "handles encoding S3 URLs without params", context do
     http_method = :get
-    url = "https://examplebucket.s3.amazonaws.com/test hello+#3.txt"
+    url = "https://examplebucket.s3.amazonaws.com/up//double//test hello+#3.txt"
     service = :s3
     request_body = ""
 
@@ -78,7 +78,7 @@ defmodule ExAws.RequestTest do
       ExAws.Request.HttpMock,
       :request,
       fn _method, url, _body, _headers, _opts ->
-        assert url == "https://examplebucket.s3.amazonaws.com/test%20hello%2B%233.txt"
+        assert url == "https://examplebucket.s3.amazonaws.com/up//double//test%20hello%2B%233.txt"
         {:ok, %{status_code: 200}}
       end
     )


### PR DESCRIPTION
# Problem

I was getting errors when trying to download certain files with special characters from S3 such as `+` and `#`


# Solution

The root issue is that URLs were being parsed and losing some information from the URL before signing and requesting the URL. For example, if an end-user uploads a file to S3 with this filename: 
`test hello+#3.txt`, it's not URL-encoded correctly and would fail a normal web request, saying either the key didn't exist, or a 403. We need that URL-encoded to `test%20hello%2B%233.txt`. 

When parsing the URL, we currently use Elixir's built-in URI functions:

```elixir
iex(1)> URI.parse("https://examplebucket.s3.amazonaws.com/test hello+#3.txt")
%URI{
  authority: "examplebucket.s3.amazonaws.com",
  fragment: "3.txt",
  host: "examplebucket.s3.amazonaws.com",
  path: "/test hello+",
  port: 443,
  query: nil,
  scheme: "https",
  userinfo: nil
}
```

Notice the path is mangled to `/test hello+` now missing the rest of the URL `#3.txt`. This is correct to the RFC spec which Elixir follows, but we need to URL-encode it first (but without `URI.parse` so it doesn't drop information), but not the entire URL (we don't want `http%3A//`)

This causes two issues:

1. The request path is wrong
2. The signature is generated on the wrong path; so even if the request path is corrected, the signature won't match. 

What I did to help prevent it

- Consolidate URI functions into `ExAws.Request.Url`. Some was happening in `ExAws.Auth.Utils`, and some in `ExAws.Request`. I figured these were all about the URL, so I moved it to that module. I kept the public functions, but passing them through to the new location. It seemed like the URL wrestling was happening in a couple places, so I moved it closer to the signature generation.
- Implemented a crude (help me out here!) way to get the path of the URL, without using `URI.parse` to keep the s3 bucket object path.
- The `+` character was being transformed to a space character too early. The character in filenames needs to be transformed to `%2B`. 
- This new code path is limited to the S3 service, so it shouldn't affect other services (they'll continue to use `URI.parse`).

# Open Questions:

1. Without changing the users' filenames, is there an expectation for a ExAws user (me) to URL-encode things before using ExAws?
2. I found that `service` was passed into these functions in different ways. I saw `"s3"` and `:s3` in the test suite. Are there other variations?
3. I did change some functions and move them, but don't want to break semver. Can someone verify if this breaks semver?
4. I didn't find any AWS docs, examples, or SDKs that had a test around these scenarios. If you find any, that would be really helpful to ensure this is signing correctly (test suite is passing though). [There is confirmation from AWS that they're weird :)](https://forums.aws.amazon.com/thread.jspa?threadID=55746). [There is documentation saying that S3 is treated special for URI encoding when generating the Authorization signature](https://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html) (screenshot below).
5. The new tests that cover these scenarios are trusted with the fact that I have another app using this branch of ExAws and it worked. I'm using these functions: 

```elixir
ExAws.S3.Download.get_chunk(
  ExAws.S3.download_file("us-east-1", "my bad file+name#3.csv", tmp_file),
  %{start_byte: 0, end_byte: 1024},
  ExAws.Config.new(:s3)
)

# and

"us-east-1"
|> ExAws.S3.download_file("my bad file+name#3.csv", tmp_file)
|> ExAws.request()

# and 

ExAws.S3.presigned_url(
  ExAws.Config.new(:s3),
  :get,
  "us-east-1",
  "my bad file+name#3.csv"
)
```


![image](https://user-images.githubusercontent.com/643967/68512117-78bef180-0245-11ea-92f4-4945044b6e7c.png)
 

### Lessons for other developers
Hey, you (and future me!) don't let users upload crazy stuff. Cleanse your user uploads' filenames into normal ascii url-encodeable ways (or error it) before upload to S3 so you avoid this problem. Do something like this (when you launch the feature, not after since this would break older uploaded files)

```elixir
@unallowed_chars ~r|[^a-zA-Z0-9.\-_~!$'()*+,;=:@]|
uploaded_filename = ~s|test hello$-_.+!*'()~"<>#%{}\|\^[]`.txt|
cleansed_filename = String.replace(uploaded_filename, @unallowed_chars, "_")
#=> "test_hello$-_.+!*'()~____________.txt"
```
