### PR TITLE
Add eu-c-1 region to list of Translate endpoints

### DIFF
--- a/priv/endpoints.exs
+++ b/priv/endpoints.exs
@@ -188,7 +188,8 @@
             "eu-west-1" => %{},
             "us-east-1" => %{},
             "us-east-2" => %{},
-            "us-west-2" => %{}
+            "us-west-2" => %{},
+            "eu-central-1" => %{}
           }
         },
         "acm" => %{


### PR DESCRIPTION
Add eu-central-1 region to the list of AWS translate endpoints in order to support the requests to AWS Translate API in this region.