### PR TITLE
Parse the credential_process config value

### DIFF
--- a/lib/ex_aws/credentials_ini.ex
+++ b/lib/ex_aws/credentials_ini.ex
@@ -3,7 +3,7 @@ if Code.ensure_loaded?(ConfigParser) do
     # as per https://docs.aws.amazon.com/cli/latest/topic/config-vars.html
     @valid_config_keys ~w(
       aws_access_key_id aws_secret_access_key aws_session_token region
-      role_arn source_profile credential_source external_id mfa_serial role_session_name
+      role_arn source_profile credential_source external_id mfa_serial role_session_name credential_process
     )
 
     def security_credentials(profile_name) do


### PR DESCRIPTION
The AWS CLI supports specifying a "credential process", which is a
command that can be run once or periodically to fetch credentials in a
specified JSON format.

https://docs.aws.amazon.com/cli/latest/topic/config-vars.html#sourcing-credentials-from-external-processes

While this commit does not add support for actually running the command,
it does make it possible to run

    ExAws.CredentialsIni.security_credentials("my_profile")

and get back `credential_process` as one of the configuration values in
the map, such as

    %{
      credential_process: "my_command -user me -role some_role",
      region: "us-west-2"
    }