### PR TITLE
Unsignable request headers

### DIFF
--- a/lib/ex_aws/auth.ex
+++ b/lib/ex_aws/auth.ex
@@ -7,7 +7,8 @@ defmodule ExAws.Auth do
 
   @moduledoc false
 
-  @unsignable_headers ["X-Amzn-Trace-Id", "x-amzn-trace-id"]
+  @unsignable_headers ["x-amzn-trace-id"]
+  @unsignable_headers_multi_case ["x-amzn-trace-id", "X-Amzn-Trace-Id"]
 
   def validate_config(config) do
     with :ok <- get_key(config, :secret_access_key),
@@ -253,7 +254,7 @@ defmodule ExAws.Auth do
   defp canonical_headers(headers) do
     headers
     |> Enum.reduce([], fn
-      {k, _v}, acc when k in @unsignable_headers -> acc
+      {k, _v}, acc when k in @unsignable_headers_multi_case -> acc
       {k, v}, acc when is_binary(v) -> [{String.downcase(to_string(k)), String.trim(v)} | acc]
       {k, v}, acc -> [{String.downcase(to_string(k)), v} | acc]
     end)

--- a/test/ex_aws/auth_test.exs
+++ b/test/ex_aws/auth_test.exs
@@ -177,6 +177,23 @@ defmodule ExAws.AuthTest do
       refute String.contains?(auth_header, "x-amzn-trace-id")
     end
 
+    test "keeps unsignable headers in the headers list" do
+      assert {:ok, headers} =
+      headers(
+        :get,
+        "https://my-bucket.s3-eu-west-1.amazonaws.com",
+        :s3,
+        @config,
+        [
+          {"X-Amzn-Trace-Id", "1-aaaaaaa-bbbbbbbbbbbbb"},
+          {"content-type", "application/json"}
+        ],
+        body = ""
+      )
+
+      assert {"X-Amzn-Trace-Id", "1-aaaaaaa-bbbbbbbbbbbbb"} = List.keyfind(headers, "X-Amzn-Trace-Id", 0)
+    end
+
     test "when security token is provided" do
       assert {:ok, headers} =
                headers(

--- a/test/ex_aws/auth_test.exs
+++ b/test/ex_aws/auth_test.exs
@@ -3,6 +3,7 @@ defmodule ExAws.AuthTest do
 
   import ExAws.Auth,
     only: [
+      headers: 6,
       build_canonical_request: 5
     ]
 
@@ -23,6 +24,16 @@ defmodule ExAws.AuthTest do
 
     path = URI.parse("http://foo.com/bar:baz@blag").path |> uri_encode
     assert build_canonical_request(:get, path, "", %{}, "") == expected
+  end
+
+  test "build_canonical_request ignores unsignable headers" do
+    path = URI.parse("http://foo.com/bar:baz@blag").path |> uri_encode
+    without_unsignable_header = build_canonical_request(:get, path, "", %{}, "")
+    with_unsignable_header = build_canonical_request(:get, path, "", %{
+      "X-Amzn-Trace-Id" => "1-aaaaaaa-bbbbbbbbbbbbb"
+    }, "")
+
+    assert with_unsignable_header == without_unsignable_header
   end
 
   test "presigned url" do
@@ -134,5 +145,54 @@ defmodule ExAws.AuthTest do
     config = ExAws.Config.new(:s3, host: "nyc3.digitaloceanspaces.com", region: "nyc3")
     assert config.region == "nyc3"
     assert config.host == "nyc3.digitaloceanspaces.com"
+  end
+
+  describe "headers/6" do
+    @config ExAws.Config.new(:s3,
+      host: "nyc3.digitaloceanspaces.com",
+      region: "eu-west-1",
+      secret_access_key: "",
+      access_key_id: ""
+    )
+
+    test "builds authentication headers with X-Amzn-Trace-Id" do
+      assert {:ok, headers} =
+               headers(
+                 :get,
+                 "https://my-bucket.s3-eu-west-1.amazonaws.com",
+                 :s3,
+                 @config,
+                 [
+                   {"X-Amzn-Trace-Id", "1-aaaaaaa-bbbbbbbbbbbbb"},
+                   {"content-type", "application/json"}
+                 ],
+                 body = ""
+               )
+
+      {"Authorization", auth_header} = List.keyfind(headers, "Authorization", 0)
+      assert String.contains?(auth_header, "x-amz-date")
+      assert String.contains?(auth_header, "host")
+      assert String.contains?(auth_header, "content-type")
+      refute String.contains?(auth_header, "x-amz-security-token")
+      refute String.contains?(auth_header, "x-amzn-trace-id")
+    end
+
+    test "when security token is provided" do
+      assert {:ok, headers} =
+               headers(
+                 :get,
+                 "https://my-bucket.s3-eu-west-1.amazonaws.com",
+                 :s3,
+                 @config |> Map.put(:security_token, "abc"),
+                 [
+                   {"content-type", "application/json"}
+                 ],
+                 body = ""
+               )
+
+      {"Authorization", auth_header} = List.keyfind(headers, "Authorization", 0)
+
+      assert String.contains?(auth_header, "x-amz-security-token")
+    end
   end
 end


### PR DESCRIPTION
Specifies a list of unsignable headers that are not used for the signature in the authorisation header. This is required as the `X-Amzn-Trace-Id` header can be sent, but should not be used in the Signature in the request's `Authorization` header. This is confirmed by the [js-sdk](https://github.com/aws/aws-sdk-js/blob/master/lib/signers/v4.js#L191-L199).

I am not too convinced by having the `unsignable_headers` list specify both uppercase and lowercase formats. I did originally have another iteration over the headers after the current `Enum.map` where the keys would always be downcased, perhaps this is better? Happy to discuss/change this!

I am aware that not everyone will be using the unsignable headers such as the `X-Amzn-Trace-Id` and therefore have tried to make as small impact on performance as I can.

This PR is related to https://github.com/ex-aws/ex_aws_lambda/pull/3