### PR TITLE
Use common config for runtime region value

### DIFF
--- a/lib/ex_aws/config.ex
+++ b/lib/ex_aws/config.ex
@@ -46,7 +46,7 @@ defmodule ExAws.Config do
         || Map.get(service_config, :region)
         || Map.get(common_config, :region)
         || "us-east-1")
-      |> retrieve_runtime_value(%{})
+      |> retrieve_runtime_value(common_config)
 
     defaults = ExAws.Config.Defaults.get(service, region)
 


### PR DESCRIPTION
The current implementation can end up with an issue where the `json_codec` value is not present and fetching region at runtime fails.