### PR TITLE
Relax Jason dependency version

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -35,7 +35,7 @@ defmodule ExAws.Mixfile do
       {:sweet_xml, "~> 0.6", optional: true},
       {:ex_doc, "~> 0.16", only: [:dev, :test]},
       {:hackney, "~> 1.9", optional: true},
-      {:jason, "~> 1.1.0", optional: true},
+      {:jason, "~> 1.1", optional: true},
       {:jsx, "~> 2.8", optional: true},
       {:dialyze, "~> 0.2.0", only: [:dev, :test]},
       {:mox, "~> 0.3", only: :test},


### PR DESCRIPTION
With the release of Jason 1.2, having a dependecy on `~> 1.1.0` becomes
a problem. Example:

```
Failed to use "jason" because
  [...]
  ex_aws (version 2.1.2) requires ~> 1.1.0
```

This can be resolved by simply depending on `~> 1.1`.