### PR TITLE
High concurrency on ets can cause dirty cache to leak empty/wrong auth

### DIFF
--- a/lib/ex_aws/config/auth_cache.ex
+++ b/lib/ex_aws/config/auth_cache.ex
@@ -25,8 +25,11 @@ defmodule ExAws.Config.AuthCache do
 
   def get(profile, expiration) do
     case :ets.lookup(__MODULE__, :awscli) do
-      [{:awscli, auth_config}] -> auth_config
-      [] -> GenServer.call(__MODULE__, {:refresh_awscli_config, profile, expiration}, 30_000)
+      [{:awscli, auth_config}] ->
+        auth_config
+
+      [] ->
+        GenServer.call(__MODULE__, {:refresh_awscli_config, profile, expiration}, 30_000)
     end
   end
 
@@ -61,18 +64,19 @@ defmodule ExAws.Config.AuthCache do
     Process.send_after(self(), {:refresh_awscli_config, profile, expiration}, expiration)
 
     auth = ExAws.CredentialsIni.security_credentials(profile)
+
+    auth =
+      case ExAws.Config.awscli_auth_adapter() do
+        nil ->
+          auth
+
+        adapter ->
+          adapter.adapt_auth_config(auth, profile, expiration)
+      end
+
     :ets.insert(ets, {:awscli, auth})
 
-    case ExAws.Config.awscli_auth_adapter() do
-      nil ->
-        auth
-
-      adapter ->
-        auth = adapter.adapt_auth_config(auth, profile, expiration)
-        :ets.insert(ets, {:awscli, auth})
-
-        auth
-    end
+    auth
   end
 
   def refresh_config(config, ets) do

--- a/test/ex_aws/auth/auth_cache_test.exs
+++ b/test/ex_aws/auth/auth_cache_test.exs
@@ -1,0 +1,74 @@
+defmodule ExAws.AuthCacheTest do
+  use ExUnit.Case, async: false
+
+  import Mox
+
+  @response {:ok, %{status_code: 200, body: %{}}}
+
+  @config [
+    http_client: ExAws.Request.HttpMock,
+    access_key_id: [{:awscli, "xpto", 1}],
+    secret_access_key: [{:awscli, "xpto", 1}]
+  ]
+
+  defmodule SleepAdapter do
+    @moduledoc false
+
+    @behaviour ExAws.Config.AuthCache.AuthConfigAdapter
+
+    @config %{
+      access_key_id: "AKIAIOSFODNN7EXAMPLE",
+      secret_access_key: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+      region: "us-east-1"
+    }
+
+    @impl true
+    def adapt_auth_config(_config, _profile, _expiration) do
+      Process.sleep(200)
+      @config
+    end
+  end
+
+  setup do
+    Application.put_env(:ex_aws, :awscli_auth_adapter, SleepAdapter)
+
+    :ok
+  end
+
+  test "using adapter does not leak dirty cache" do
+    parent = self()
+
+    op = %ExAws.Operation.S3{
+      body: "",
+      bucket: "",
+      headers: %{},
+      http_method: :get,
+      params: [],
+      parser: & &1,
+      path: "/",
+      resource: "",
+      service: :s3,
+      stream_builder: nil
+    }
+
+    spawn(fn ->
+      ExAws.Request.HttpMock
+      |> expect(:request, fn _method, _url, _body, _headers, _opts ->
+        @response
+      end)
+
+      result = ExAws.request(op, @config)
+      send(parent, result)
+    end)
+
+    ExAws.Request.HttpMock
+    |> expect(:request, fn _method, _url, _body, _headers, _opts ->
+      @response
+    end)
+
+    Process.sleep(100)
+    assert ExAws.request(op, @config) == @response
+
+    assert_receive @response, 1000
+  end
+end


### PR DESCRIPTION
In a high throughput application using the `awscli_auth_adapter` option we were seeing a small percent of errors that seem to correlate with the `AuthCache` refresh period:

`{:error, "Required key: :secret_access_key is nil in config!"}`

This can happen as the auth config loaded from the configuration file (that can be used for the adapter but is not the final credentials to be used for AWS requests - as it may not have the same permissions or can even be empty when using ENV vars) is temporarily stored in `:ets` that can be concurrently read.

The attached unit test was able to reproduce the issue and is currently passing with the proposed fix.