### PR TITLE
Add connect to endpoint default configuration

### DIFF
--- a/priv/endpoints.exs
+++ b/priv/endpoints.exs
@@ -30,6 +30,17 @@
         "us-west-2" => %{"description" => "US West (Oregon)"}
       },
       "services" => %{
+        "connect" => %{
+          "endpoints" => %{
+            "ap-northeast-1" => %{},
+            "ap-southeast-1" => %{},
+            "ap-southeast-2" => %{},
+            "eu-central-1" => %{},
+            "eu-west-2" => %{},
+            "us-east-1" => %{},
+            "us-west-2" => %{}
+          }
+        },
         "firehose" => %{
           "endpoints" => %{
             "ap-northeast-1" => %{},


### PR DESCRIPTION
This facilitates the creation of an `ex_aws_connect` library. Otherwise I'm finding that in spite of adding `config :ex_aws, :connect, ...` there will always be an exception from `ExAws.Config.Defaults.fetch_or/3`.