### PR TITLE
added ap-southeast-1 endpoint for rekognition

### DIFF
--- a/priv/endpoints.exs
+++ b/priv/endpoints.exs
@@ -1199,6 +1199,7 @@
         "rekognition" => %{
           "endpoints" => %{
             "ap-northeast-1" => %{},
+            "ap-southeast-1" => %{},
             "ap-southeast-2" => %{},
             "eu-west-1" => %{},
             "us-east-1" => %{},


### PR DESCRIPTION
Rekognition is already supported in ap-southeast-1 as per:

https://aws.amazon.com/about-aws/whats-new/2019/06/amazon-rekognition-available-four-additional-aws-regions/