### PR TITLE
HTTP header value should be a String (binary)

### DIFF
--- a/lib/ex_aws/operation/s3.ex
+++ b/lib/ex_aws/operation/s3.ex
@@ -43,7 +43,7 @@ defmodule ExAws.Operation.S3 do
     defp put_content_length_header(headers, "", :get), do: headers
 
     defp put_content_length_header(headers, body, _) do
-      Map.put(headers, "content-length", byte_size(body))
+      Map.put(headers, "content-length", byte_size(body) |> Integer.to_string())
     end
 
     def stream!(%{stream_builder: fun}, config) do


### PR DESCRIPTION
As per type spec contract on `ExAws.Request.HttpClient` the `request` callback ask for `headers :: [{binary, binary}, ...]`:

```elixir
  @type http_method :: :get | :post | :put | :delete
  @callback request(
              method :: http_method,
              url :: binary,
              req_body :: binary,
              headers :: [{binary, binary}, ...],
              http_opts :: term
            ) ::
              {:ok, %{status_code: pos_integer, body: binary}}
              | {:error, %{reason: any}}
```

in this case we have `{"content-length": 13}` where the value is an int.

NOTE: it works now with the default hackney client because it accepts and coverts this type
https://github.com/benoitc/hackney/blob/2f55c0d37f9d5942b976272a1df5adecca4edc61/src/hackney_bstr.erl#L30
I've noticed this because I'm using a different HTTP client and I expected to receive a `[{binary, binary}]`