### PR TITLE
Timestream AWS service - add endpoints

### DIFF
--- a/lib/ex_aws/config/defaults.ex
+++ b/lib/ex_aws/config/defaults.ex
@@ -49,6 +49,16 @@ defmodule ExAws.Config.Defaults do
     |> Map.merge(defaults(:qldb))
   end
 
+  def defaults(:ingest_timestream) do
+    %{service_override: :timestream}
+    |> Map.merge(defaults(:timestream))
+  end
+
+  def defaults(:query_timestream) do
+    %{service_override: :timestream}
+    |> Map.merge(defaults(:timestream))
+  end
+
   def defaults(_) do
     Map.merge(
       %{
@@ -89,6 +99,8 @@ defmodule ExAws.Config.Defaults do
   defp service_map(:lex_models), do: "models.lex"
   defp service_map(:dynamodb_streams), do: "streams.dynamodb"
   defp service_map(:iot_data), do: "data.iot"
+  defp service_map(:ingest_timestream), do: "ingest.timestream"
+  defp service_map(:query_timestream), do: "query.timestream"
 
   defp service_map(service) do
     service

--- a/priv/endpoints.exs
+++ b/priv/endpoints.exs
@@ -198,6 +198,22 @@
             "us-west-2" => %{}
           }
         },
+        "ingest.timestream" => %{
+          "endpoints" => %{
+            "us-east-1" => %{},
+            "us-east-2" => %{},
+            "us-west-2" => %{},
+            "eu-west-1" => %{}
+          }
+        },
+        "query.timestream" => %{
+          "endpoints" => %{
+            "us-east-1" => %{},
+            "us-east-2" => %{},
+            "us-west-2" => %{},
+            "eu-west-1" => %{}
+          }
+        },
         "translate" => %{
           "defaults" => %{"protocols" => ["https"]},
           "endpoints" => %{


### PR DESCRIPTION
Amazon Timestream is available in US East (N. Virginia), US East (Ohio), US West (Oregon), and EU (Ireland), with availability in additional regions in the coming months.

Amazon Timestream is split into two services 
- [Amazon Timestream Write](https://github.com/aws/aws-sdk-go/blob/master/models/apis/timestream-write/2018-11-01/api-2.json)
- [Amazon Timestream Query](https://github.com/aws/aws-sdk-go/blob/master/models/apis/timestream-query/2018-11-01/api-2.json)


This PR adds valid endpoints and valid configurations

Example:

```elixir
%ExAws.Operation.JSON{
  http_method: :post,
  service: :ingest_timestream,
  data: %{},
  headers: [
    {"x-amz-target", "Timestream_20181101.DescribeEndpoints"},
    {"content-type", "application/x-amz-json-1.0"}
  ]
} |> ExAws.request(region: "us-west-2")
```

Response:

```elixir
{:ok,
 %{
   "Endpoints" => [
     %{
       "Address" => "ingest-cell1.timestream.us-west-2.amazonaws.com",
       "CachePeriodInMinutes" => 1440
     }
   ]
 }}
```


