### PR TITLE
Fix Elixir 1.11 compiler warning

### DIFF
--- a/lib/ex_aws.ex
+++ b/lib/ex_aws.ex
@@ -87,10 +87,8 @@ defmodule ExAws do
   @doc false
   @impl Application
   def start(_type, _args) do
-    import Supervisor.Spec, warn: false
-
     children = [
-      worker(ExAws.Config.AuthCache, [[name: ExAws.Config.AuthCache]])
+      {ExAws.Config.AuthCache, [name: ExAws.Config.AuthCache]}
     ]
 
     opts = [strategy: :one_for_one, name: ExAws.Supervisor]

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule ExAws.Mixfile do
     [
       app: :ex_aws,
       version: @version,
-      elixir: "~> 1.4",
+      elixir: "~> 1.5",
       elixirc_paths: elixirc_paths(Mix.env()),
       description: "Generic AWS client",
       name: "ExAws",

--- a/test/ex_aws/auth_test.exs
+++ b/test/ex_aws/auth_test.exs
@@ -166,7 +166,7 @@ defmodule ExAws.AuthTest do
                    {"X-Amzn-Trace-Id", "1-aaaaaaa-bbbbbbbbbbbbb"},
                    {"content-type", "application/json"}
                  ],
-                 body = ""
+                 _body = ""
                )
 
       {"Authorization", auth_header} = List.keyfind(headers, "Authorization", 0)
@@ -188,7 +188,7 @@ defmodule ExAws.AuthTest do
           {"X-Amzn-Trace-Id", "1-aaaaaaa-bbbbbbbbbbbbb"},
           {"content-type", "application/json"}
         ],
-        body = ""
+        _body = ""
       )
 
       assert {"X-Amzn-Trace-Id", "1-aaaaaaa-bbbbbbbbbbbbb"} = List.keyfind(headers, "X-Amzn-Trace-Id", 0)
@@ -204,7 +204,7 @@ defmodule ExAws.AuthTest do
                  [
                    {"content-type", "application/json"}
                  ],
-                 body = ""
+                 _body = ""
                )
 
       {"Authorization", auth_header} = List.keyfind(headers, "Authorization", 0)


### PR DESCRIPTION
This addresses the the following compiler warning when using Elixir 1.11:

```
warning: Supervisor.Spec.worker/2 is deprecated. Use the new child specifications outlined in the Supervisor module instead
  lib/ex_aws.ex:93: ExAws.start/2
```

Also, fixed the `unused variables` warnings when running `mix test` as well. The min version was bumped to `1.5` since that was when the new Supervisor changes was added in.