### PR TITLE
Extra HTML doc changes and fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ elixir: 1.9
 notifications:
   recipients:
     - ben.wilson@cargosense.com
+    - bernard@circl.es
 otp_release:
   - 22.1
 before_script:

--- a/lib/ex_aws.ex
+++ b/lib/ex_aws.ex
@@ -1,8 +1,7 @@
 defmodule ExAws do
-  @moduledoc "#{__DIR__}/../README.md"
-             |> File.read!()
-             |> String.split("<!-- MDOC !-->")
-             |> Enum.fetch!(1)
+  @moduledoc """
+  Module for making and processing AWS request
+  """
 
   use Application
 

--- a/mix.exs
+++ b/mix.exs
@@ -47,7 +47,10 @@ defmodule ExAws.Mixfile do
       files: ["priv", "lib", "config", "mix.exs", "README*"],
       maintainers: ["Bernard Duggan", "Ben Wilson"],
       licenses: ["MIT"],
-      links: %{GitHub: @source_url}
+      links: %{
+        Changelog: "#{@source_url}/blob/master/CHANGELOG.md",
+        GitHub: @source_url
+      }
     ]
   end
 
@@ -60,9 +63,10 @@ defmodule ExAws.Mixfile do
 
   defp docs do
     [
-      main: "ExAws",
+      main: "readme",
       source_ref: "v#{@version}",
-      source_url: @source_url
+      source_url: @source_url,
+      extras: ["README.md"]
     ]
   end
 end


### PR DESCRIPTION
List of changes:
- Add maintainer email to Travis CI notification
- Add changelog link to hex module info page
- Set readme as HTML doc default page which fix the badges issue. See screenshot.

![image](https://user-images.githubusercontent.com/134518/96457126-f7901d00-1251-11eb-95a2-2a5a8cb441ed.png)


