### PR TITLE
Use S3 virtual hosted style urls

### DIFF
--- a/lib/ex_aws/operation/s3.ex
+++ b/lib/ex_aws/operation/s3.ex
@@ -24,7 +24,6 @@ defmodule ExAws.Operation.S3 do
 
       url =
         operation
-        |> add_bucket_to_path
         |> add_resource_to_params
         |> ExAws.Request.Url.build(config)
 
@@ -48,11 +47,6 @@ defmodule ExAws.Operation.S3 do
 
     def stream!(%{stream_builder: fun}, config) do
       fun.(config)
-    end
-
-    def add_bucket_to_path(operation) do
-      path = "/#{operation.bucket}/#{operation.path}" |> String.trim_leading("//")
-      operation |> Map.put(:path, path)
     end
 
     def add_resource_to_params(operation) do

--- a/lib/ex_aws/request/url.ex
+++ b/lib/ex_aws/request/url.ex
@@ -7,6 +7,7 @@ defmodule ExAws.Request.Url do
   def build(operation, config) do
     config
     |> Map.take([:scheme, :host, :port])
+    |> set_host(operation)
     |> Map.put(:query, query(operation))
     |> Map.put(:path, operation.path)
     |> normalize_scheme
@@ -15,6 +16,16 @@ defmodule ExAws.Request.Url do
     |> (&struct(URI, &1)).()
     |> URI.to_string()
     |> String.trim_trailing("?")
+  end
+
+  defp set_host(config, operation) do
+    case operation do
+      %ExAws.Operation.S3{} ->
+        %{config | host: "#{operation.bucket}.s3.amazonaws.com"}
+
+      _ ->
+        %{config | host: config.host}
+    end
   end
 
   defp query(operation) do


### PR DESCRIPTION
I've been running into an issue where I get a redirect error when trying to do a S3 PutObject:

```
# [warn] ExAws: Received redirect, did you specify the correct region?
# {:error, {:http_error, 301, "redirected"}}
```

After digging around on the internet for a while, I realized that if I update ExAws to use "virtual host-style" instead of "path style", everything works fine. I'm actually not really sure what the actual problem was, but I do think this is a change that is ok.

I'm not entirely sure about the implementation though. Making the Url module aware of S3 operations doesn't seem like the most awesome design. If someone has any idea how to solve this differently I'll be happy to try it out. 

Also, I haven't run the tests other than the ones for the Url module. If this seems like an ok way forward, I'll try to get the tests to run, but I wanted some feedback on the code f

More information can be found at [1] and according to the latest docs [2], all
S3 requests should use the virtual host style urls.

[1] https://aws.amazon.com/blogs/aws/amazon-s3-path-deprecation-plan-the-rest-of-the-story/
[2] https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html#API_PutObject_RequestSyntax