### PR TITLE
Support for af-south-1

### DIFF
--- a/lib/ex_aws/config/defaults.ex
+++ b/lib/ex_aws/config/defaults.ex
@@ -77,7 +77,7 @@ defmodule ExAws.Config.Defaults do
   end
 
   @partitions [
-    {~r/^(us|eu|ap|sa|ca)\-\w+\-\d+$/, "aws"},
+    {~r/^(us|eu|af|ap|sa|ca)\-\w+\-\d+$/, "aws"},
     {~r/^cn\-\w+\-\d+$/, "aws-cn"},
     {~r/^us\-gov\-\w+\-\d+$/, "aws-us-gov"}
   ]

--- a/priv/endpoints.exs
+++ b/priv/endpoints.exs
@@ -1376,6 +1376,7 @@
             "hostname" => "sts.amazonaws.com"
           },
           "endpoints" => %{
+            "af-south-1" => %{},
             "ap-northeast-1" => %{},
             "ap-northeast-2" => %{
               "credentialScope" => %{"region" => "ap-northeast-2"},

--- a/priv/endpoints.exs
+++ b/priv/endpoints.exs
@@ -9,8 +9,9 @@
       "dnsSuffix" => "amazonaws.com",
       "partition" => "aws",
       "partitionName" => "AWS Standard",
-      "regionRegex" => "^(us|eu|ap|sa|ca)\\-\\w+\\-\\d+$",
+      "regionRegex" => "^(us|eu|af|ap|sa|ca)\\-\\w+\\-\\d+$",
       "regions" => %{
+        "af-south-1" => %{"description" => "Africa (Cape Town)"},
         "ap-northeast-1" => %{"description" => "Asia Pacific (Tokyo)"},
         "ap-northeast-2" => %{"description" => "Asia Pacific (Seoul)"},
         "ap-east-1" => %{"description" => "Asia Pacific (Hong Kong)"},
@@ -45,6 +46,7 @@
         },
         "firehose" => %{
           "endpoints" => %{
+            "af-south-1" => %{},
             "ap-northeast-1" => %{},
             "ap-southeast-1" => %{},
             "ap-southeast-2" => %{},
@@ -111,6 +113,7 @@
         },
         "config" => %{
           "endpoints" => %{
+            "af-south-1" => %{},
             "ap-northeast-1" => %{},
             "ap-northeast-2" => %{},
             "ap-east-1" => %{},
@@ -164,6 +167,7 @@
         },
         "snowball" => %{
           "endpoints" => %{
+            "af-south-1" => %{},
             "ap-northeast-1" => %{},
             "ap-south-1" => %{},
             "ap-southeast-1" => %{},
@@ -412,6 +416,7 @@
         "sns" => %{
           "defaults" => %{"protocols" => ["http", "https"]},
           "endpoints" => %{
+            "af-south-1" => %{},
             "ap-northeast-1" => %{},
             "ap-northeast-2" => %{},
             "ap-east-1" => %{},
@@ -434,6 +439,7 @@
         "health" => %{"endpoints" => %{"us-east-1" => %{}}},
         "glue" => %{
           "endpoints" => %{
+            "af-south-1" => %{},
             "ap-northeast-1" => %{},
             "ap-northeast-2" => %{},
             "ap-south-1" => %{},
@@ -486,6 +492,7 @@
         },
         "lambda" => %{
           "endpoints" => %{
+            "af-south-1" => %{},
             "ap-northeast-1" => %{},
             "ap-northeast-2" => %{},
             "ap-east-1" => %{},
@@ -779,6 +786,7 @@
         "ec2" => %{
           "defaults" => %{"protocols" => ["http", "https"]},
           "endpoints" => %{
+            "af-south-1" => %{},
             "ap-northeast-1" => %{},
             "ap-northeast-2" => %{},
             "ap-east-1" => %{},
@@ -869,6 +877,7 @@
         },
         "apigateway" => %{
           "endpoints" => %{
+            "af-south-1" => %{},
             "ap-northeast-1" => %{},
             "ap-northeast-2" => %{},
             "ap-east-1" => %{},
@@ -937,6 +946,7 @@
         },
         "sms" => %{
           "endpoints" => %{
+            "af-south-1" => %{},
             "ap-northeast-1" => %{},
             "ap-northeast-2" => %{},
             "ap-south-1" => %{},
@@ -956,6 +966,7 @@
         },
         "rds" => %{
           "endpoints" => %{
+            "af-south-1" => %{},
             "ap-northeast-1" => %{},
             "ap-northeast-2" => %{},
             "ap-east-1" => %{},
@@ -1291,6 +1302,7 @@
         },
         "elasticbeanstalk" => %{
           "endpoints" => %{
+            "af-south-1" => %{},
             "ap-northeast-1" => %{},
             "ap-northeast-2" => %{},
             "ap-east-1" => %{},


### PR DESCRIPTION
This adds support for the Cape Town region. 

The region has not been added to some, but not all the services that are available in Cape Town. 

The endpoints.exs file seems to have a striking resemblance to this file, 
https://github.com/boto/botocore/blob/master/botocore/data/endpoints.json, as mentioned in this post: 
https://www.transposit.com/blog/2019.10.21-aws-regions-api/

Can I update the contents of priv/endpoints.exs with the contents of the endpoints.json file from Boto? 
