### PR TITLE
Add us-east-2 as allowable SES email endpoint

### DIFF
--- a/priv/endpoints.exs
+++ b/priv/endpoints.exs
@@ -1549,6 +1549,7 @@
             "eu-west-1" => %{},
             "eu-west-2" => %{},
             "us-east-1" => %{},
+            "us-east-2" => %{},
             "us-west-2" => %{},
             "ca-central-1" => %{},
             "sa-east-1" => %{}


### PR DESCRIPTION
SES is supported in `us-east-2`. I've tested this fork in AWS and received an email from my domain.

![image](https://user-images.githubusercontent.com/97087/102659326-14e84700-412e-11eb-8f0f-0c744bfead30.png)
