### PR TITLE
Use :crypto.mac/4 instead of :crypto.hmac/3

### DIFF
--- a/lib/ex_aws/auth/utils.ex
+++ b/lib/ex_aws/auth/utils.ex
@@ -9,8 +9,18 @@ defmodule ExAws.Auth.Utils do
     |> bytes_to_hex
   end
 
-  def hmac_sha256(key, data) do
-    :crypto.hmac(:sha256, key, data)
+  # :crypto.mac/4 is introduced in Erlang/OTP 22.1 and :crypto.hmac/3 is removed
+  # in Erlang/OTP 24. The check is needed for backwards compatibility.
+  # The Code.ensure_loaded/1 call is executed so function_expored?/3 can be used
+  # to determine which function to use.
+  Code.ensure_loaded?(:crypto) || IO.warn(":crypto module failed to load")
+
+  case function_exported?(:crypto, :mac, 4) do
+    true ->
+      def hmac_sha256(key, data), do: :crypto.mac(:hmac, :sha256, key, data)
+
+    false ->
+      def hmac_sha256(key, data), do: :crypto.hmac(:sha256, key, data)
   end
 
   def bytes_to_hex(bytes) do


### PR DESCRIPTION
:crypto.hmac/{3,4} is deprecated and will be removed in Erlang/OTP 24.
:crypto.mac/4 is used instead. It is available since Erlang/OTP 22.1, so some availability checks must be performed.