### PR TITLE
Attempt to fix presigned urls with query strings

### DIFF
--- a/lib/ex_aws/auth.ex
+++ b/lib/ex_aws/auth.ex
@@ -122,11 +122,11 @@ defmodule ExAws.Auth do
   defp handle_temp_credentials(headers, _), do: headers
 
   defp auth_header(http_method, url, headers, body, service, datetime, config) do
-    uri = URI.parse(url)
     query =
-      if uri.query,
-        do: uri.query |> URI.decode_query() |> Enum.to_list() |> canonical_query_params,
-        else: ""
+      url
+      |> URI.parse()
+      |> query_from_parsed_uri()
+      |> canonical_query_params()
 
     signature = signature(http_method, url, query, headers, body, service, datetime, config)
 
@@ -141,6 +141,14 @@ defmodule ExAws.Auth do
       signature
     ]
     |> IO.iodata_to_binary()
+  end
+
+  defp query_from_parsed_uri(%{query: nil}), do: []
+
+  defp query_from_parsed_uri(%{query: query_string}) do
+    query_string
+    |> URI.decode_query()
+    |> Enum.to_list()
   end
 
   defp signature(http_method, url, query, headers, body, service, datetime, config) do

--- a/lib/ex_aws/auth.ex
+++ b/lib/ex_aws/auth.ex
@@ -216,9 +216,12 @@ defmodule ExAws.Auth do
 
   defp canonical_query_params(params) do
     params
-    |> Enum.sort(fn {k1, _}, {k2, _} -> k1 < k2 end)
+    |> Enum.sort(&compare_query_params/2)
     |> Enum.map_join("&", &pair/1)
   end
+
+  defp compare_query_params({key, value1}, {key, value2}), do: value1 < value2
+  defp compare_query_params({key_1, _}, {key_2, _}), do: key_1 < key_2
 
   defp pair({k, _}) when is_list(k) do
     raise ArgumentError, "encode_query/1 keys cannot be lists, got: #{inspect(k)}"


### PR DESCRIPTION
This is a possible fix for #733 in which the parameters passed as part of the URL as included with the rest of the URL params, avoiding broken urls with things like "?foo=bar?X-Amz-Signature.

I am not 100% sure if this is the correct fix, but it looks so according to the documentation. Missing test suites for this code do not help, and should really be added in order to determine correctness. The best I can say is that the test suite that exists works, that  a correct test suite in `ex_aws_s3` now passes, and a local app I have written which uses `ex_aws_s3` still works as well though it is not hitting all of the affect code paths. 

Therefore, I consider this a moderately risky merge, though it does address what looks to be an obvious error?