### PR TITLE
Support virtual host style buckets

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -3,7 +3,9 @@ use Mix.Config
 config :logger, level: :warn
 
 config :ex_aws,
-  json_codec: Test.JSONCodec
+  json_codec: Test.JSONCodec,
+  access_key_id: ["test_key_id"],
+  secret_access_key: ["secret_access_key"]
 
 config :ex_aws, :kinesis,
   scheme: "https://",

--- a/lib/ex_aws/operation/s3.ex
+++ b/lib/ex_aws/operation/s3.ex
@@ -22,10 +22,11 @@ defmodule ExAws.Operation.S3 do
       headers = operation.headers
       http_method = operation.http_method
 
+      {operation, config} = add_bucket_to_path(operation, config)
+
       url =
         operation
-        |> add_bucket_to_path
-        |> add_resource_to_params
+        |> add_resource_to_params()
         |> ExAws.Request.Url.build(config)
 
       hashed_payload = ExAws.Auth.Utils.hash_sha256(body)
@@ -40,21 +41,29 @@ defmodule ExAws.Operation.S3 do
       |> operation.parser.()
     end
 
+    def stream!(%{stream_builder: fun}, config), do: fun.(config)
+
     defp put_content_length_header(headers, "", :get), do: headers
 
     defp put_content_length_header(headers, body, _) do
       Map.put(headers, "content-length", byte_size(body) |> Integer.to_string())
     end
 
-    def stream!(%{stream_builder: fun}, config) do
-      fun.(config)
+    @spec add_bucket_to_path(operation :: ExAws.Operation.S3.t(), config :: map) ::
+            {operation :: ExAws.Operation.S3.t(), config :: map}
+    def add_bucket_to_path(operation, config \\ %{})
+
+    def add_bucket_to_path(operation, %{virtual_host: true, host: base_host} = config) do
+      vhost_domain = "#{operation.bucket}.#{base_host}"
+      {operation, Map.put(config, :host, vhost_domain)}
     end
 
-    def add_bucket_to_path(operation) do
-      path = "/#{operation.bucket}/#{operation.path}" |> String.trim_leading("//")
-      operation |> Map.put(:path, path)
+    def add_bucket_to_path(operation, config) do
+      path = Path.join(["/", operation.bucket, operation.path]) |> Path.expand()
+      {operation |> Map.put(:path, path), config}
     end
 
+    @spec add_resource_to_params(operation :: ExAws.Operation.S3.t()) :: ExAws.Operation.S3.t()
     def add_resource_to_params(operation) do
       params = operation.params |> Map.new() |> Map.put(operation.resource, 1)
       operation |> Map.put(:params, params)

--- a/test/ex_aws/operation/s3_test.exs
+++ b/test/ex_aws/operation/s3_test.exs
@@ -1,0 +1,50 @@
+defmodule ExAws.Operation.S3Test do
+  use ExUnit.Case, async: true
+
+  alias Elixir.ExAws.Operation.ExAws.Operation.S3
+
+  def s3_operation() do
+    %ExAws.Operation.S3{
+      body: "",
+      bucket: "my-bucket-1",
+      headers: %{},
+      http_method: :get,
+      params: [],
+      parser: & &1,
+      path: "/folder",
+      resource: "",
+      service: :s3,
+      stream_builder: nil
+    }
+  end
+
+  test "S3 adds bucket to path when virtual_host is missing from config" do
+    config = ExAws.Config.new(:s3)
+    operation = s3_operation()
+
+    {processed_operation, processed_config} = S3.add_bucket_to_path(operation, config)
+
+    assert(processed_config.host == config.host)
+    assert(processed_operation.path == "/#{operation.bucket}#{operation.path}")
+  end
+
+  test "S3 adds bucket to path when virtual_host is false" do
+    config = ExAws.Config.new(:s3) |> Map.put(:virtual_host, false)
+    operation = s3_operation()
+
+    {processed_operation, processed_config} = S3.add_bucket_to_path(operation, config)
+
+    assert(processed_config.host == config.host)
+    assert(processed_operation.path == "/#{operation.bucket}#{operation.path}")
+  end
+
+  test "S3 adds buck to path when virtual_host is true" do
+    config = ExAws.Config.new(:s3) |> Map.put(:virtual_host, true)
+    operation = s3_operation()
+
+    {processed_operation, processed_config} = S3.add_bucket_to_path(operation, config)
+
+    assert(processed_config.host == "#{operation.bucket}.#{config.host}")
+    assert(processed_operation.path == operation.path)
+  end
+end


### PR DESCRIPTION
This is a proposed alternative approach to #726 

This is done in a backwards compatible manner to preserve existing configurations. In the next major release, consider switching the default to virtual host style as that is the current recommendation from S3 API providers.

Test coverage and typespecs for the functions were added, and I have also tested in a real-world application that uses virtual host style hostnames to differentiate buckets.