### PR TITLE
Provide fake secrets for testing purposes

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -3,7 +3,9 @@ use Mix.Config
 config :logger, level: :warn
 
 config :ex_aws,
-  json_codec: Test.JSONCodec
+  json_codec: Test.JSONCodec,
+  access_key_id: ["test_key_id"],
+  secret_access_key: ["secret_access_key"]
 
 config :ex_aws, :kinesis,
   scheme: "https://",


### PR DESCRIPTION
After the Nth failure to remember to setup the env vars expected for the API keys while testing, I added fake credentials to the test configuration. One less thing to remember, get wrong, and/or risk accessing actual data with real secrets floating in the ENV, this makes testing a bit easier.