### PR TITLE
Refactor auth cache refreshing

### DIFF
--- a/lib/ex_aws.ex
+++ b/lib/ex_aws.ex
@@ -88,7 +88,7 @@ defmodule ExAws do
   @impl Application
   def start(_type, _args) do
     children = [
-      {ExAws.Config.AuthCache, [name: ExAws.Config.AuthCache]}
+      ExAws.Config.AuthCache
     ]
 
     opts = [strategy: :one_for_one, name: ExAws.Supervisor]

--- a/lib/ex_aws/config/auth_cache.ex
+++ b/lib/ex_aws/config/auth_cache.ex
@@ -13,7 +13,7 @@ defmodule ExAws.Config.AuthCache do
   end
 
   def start_link(opts \\ []) do
-    GenServer.start_link(__MODULE__, :ok, opts)
+    GenServer.start_link(__MODULE__, :ok, Keyword.put(opts, :name, __MODULE__))
   end
 
   def get(config) do

--- a/lib/ex_aws/config/auth_cache.ex
+++ b/lib/ex_aws/config/auth_cache.ex
@@ -5,6 +5,9 @@ defmodule ExAws.Config.AuthCache do
 
   # http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html
 
+  @refresh_lead_time 300_000
+  @instance_auth_key :aws_instance_auth
+
   defmodule AuthConfigAdapter do
     @moduledoc false
 
@@ -17,10 +20,8 @@ defmodule ExAws.Config.AuthCache do
   end
 
   def get(config) do
-    case :ets.lookup(__MODULE__, :aws_instance_auth) do
-      [{:aws_instance_auth, auth_config}] -> auth_config
-      [] -> GenServer.call(__MODULE__, {:refresh_config, config}, 30_000)
-    end
+    :ets.lookup(__MODULE__, @instance_auth_key)
+    |> refresh_auth_if_required(config)
   end
 
   def get(profile, expiration) do
@@ -40,8 +41,8 @@ defmodule ExAws.Config.AuthCache do
     {:ok, ets}
   end
 
-  def handle_call({:refresh_config, config}, _from, ets) do
-    auth = refresh_config(config, ets)
+  def handle_call({:refresh_auth, config}, _from, ets) do
+    auth = refresh_auth(config, ets)
     {:reply, auth, ets}
   end
 
@@ -50,8 +51,8 @@ defmodule ExAws.Config.AuthCache do
     {:reply, auth, ets}
   end
 
-  def handle_info({:refresh_config, config}, ets) do
-    refresh_config(config, ets)
+  def handle_info({:refresh_auth, config}, ets) do
+    refresh_auth(config, ets)
     {:noreply, ets}
   end
 
@@ -79,19 +80,61 @@ defmodule ExAws.Config.AuthCache do
     auth
   end
 
-  def refresh_config(config, ets) do
+  defp refresh_auth_if_required([], config) do
+    GenServer.call(__MODULE__, {:refresh_auth, config}, 30_000)
+  end
+
+  defp refresh_auth_if_required([{_key, cached_auth}], config) do
+    if next_refresh_in(cached_auth) > 0 do
+      cached_auth
+    else
+      GenServer.call(__MODULE__, {:refresh_auth, config}, 30_000)
+    end
+  end
+
+  defp refresh_auth(config, ets) do
+    :ets.lookup(__MODULE__, @instance_auth_key)
+    |> refresh_auth_if_stale(config, ets)
+  end
+
+  defp refresh_auth_if_stale([], config, ets) do
+    refresh_auth_now(config, ets)
+  end
+
+  defp refresh_auth_if_stale([{_key, cached_auth}], config, ets) do
+    if next_refresh_in(cached_auth) > @refresh_lead_time do
+      # we still have a valid auth token, so simply return that
+      cached_auth
+    else
+      refresh_auth_now(config, ets)
+    end
+  end
+
+  defp refresh_auth_if_stale(_, config, ets), do: refresh_auth_now(config, ets)
+
+  defp refresh_auth_now(config, ets) do
     auth = ExAws.InstanceMeta.security_credentials(config)
-    :ets.insert(ets, {:aws_instance_auth, auth})
-    Process.send_after(self(), {:refresh_config, config}, refresh_in(auth[:expiration]))
+    :ets.insert(ets, {@instance_auth_key, auth})
+    Process.send_after(__MODULE__, {:refresh_auth, config}, next_refresh_in(auth))
     auth
   end
 
-  def refresh_in(expiration) do
-    expiration = expiration |> ExAws.Utils.iso_z_to_secs()
-    time_to_expiration = expiration - ExAws.Utils.now_in_seconds()
-    # check five mins prior to expiration
-    refresh_in = time_to_expiration - 5 * 60
-    # check now if we should have checked in the past
-    max(0, refresh_in * 1000)
+  defp next_refresh_in(%{expiration: expiration}) do
+    try do
+      time_to_expiration =
+        expiration
+        |> NaiveDateTime.from_iso8601!()
+        |> NaiveDateTime.diff(NaiveDateTime.utc_now())
+
+      expires_in_ms = max(0, 1000 * time_to_expiration)
+
+      # check either when it expires, or lead_time before that
+      # whichever is longer
+      max(expires_in_ms, expires_in_ms - @refresh_lead_time)
+    rescue
+      _e -> 0
+    end
   end
+
+  defp next_refresh_in(_), do: 0
 end

--- a/lib/ex_aws/utils.ex
+++ b/lib/ex_aws/utils.ex
@@ -60,33 +60,6 @@ defmodule ExAws.Utils do
   def upcase(value) when is_binary(value), do: String.upcase(value)
   def upcase(char), do: :string.to_upper(char)
 
-  @seconds_0_to_1970 :calendar.datetime_to_gregorian_seconds({{1970, 1, 1}, {0, 0, 0}})
-
-  def iso_z_to_secs(<<date::binary-10, "T", time::binary-8, "Z">> <> _) do
-    [year, mon, day] =
-      date
-      |> String.split("-")
-      |> Enum.map(&String.to_integer/1)
-
-    [hour, min, sec] =
-      time
-      |> String.split(":")
-      |> Enum.map(&String.to_integer/1)
-
-    # Seriously? Gregorian seconds but not epoch seconds?
-    greg_secs = :calendar.datetime_to_gregorian_seconds({{year, mon, day}, {hour, min, sec}})
-    greg_secs - @seconds_0_to_1970
-  end
-
-  def now_in_seconds do
-    greg_secs =
-      :os.timestamp()
-      |> :calendar.now_to_universal_time()
-      |> :calendar.datetime_to_gregorian_seconds()
-
-    greg_secs - @seconds_0_to_1970
-  end
-
   def uuid, do: DateTime.utc_now() |> :erlang.phash2()
 
   def rename_keys(params, mapping) do

--- a/test/ex_aws/utils_test.exs
+++ b/test/ex_aws/utils_test.exs
@@ -36,10 +36,6 @@ defmodule ExAws.UtilsTest do
              |> camelize_keys(spec: %{foo_bar: "non-standard"})
   end
 
-  test "iso_z_to_secs converts iso string to epoch seconds" do
-    assert 1_436_134_578 == iso_z_to_secs("2015-07-05T22:16:18Z")
-  end
-
   test "rename_keys renames keys in a list of keywords" do
     assert [d: 1, b: 2, e: 3] == [a: 1, b: 2, c: 3] |> rename_keys(a: :d, c: :e)
   end


### PR DESCRIPTION
This PR attempts to address a few different issues highlighted as a result of PR #625 including:

* enforce the singleton status of the AuthCache module
* always check returned auth and re-fetch if non-existent or expired
* only perform a scheduled refetch if the cached auth is close to expiry
* replace the hand-rolled time offset code with NaiveDateTime

It is separated into 3 different commits so each may be reviewed and easily only take parts. If this approach is acceptable and works as desired, a similar change should be made for the `:refresh_awscli_config` paths as well. 

I have very limited ability to test this thoroughly, so testing by those following PR #625 would be great welcomed.