### PR TITLE
Added eu-west-2 as an athena endpoint

### DIFF
--- a/priv/endpoints.exs
+++ b/priv/endpoints.exs
@@ -698,6 +698,7 @@
             "ap-southeast-2" => %{},
             "eu-central-1" => %{},
             "eu-west-1" => %{},
+            "eu-west-2" => %{},
             "us-east-1" => %{},
             "us-east-2" => %{},
             "us-west-2" => %{}


### PR DESCRIPTION
Athena is supported in EU-WEST-2 (London Region)