### PR TITLE
Allow STS credentials to be injected by configuration

### DIFF
--- a/lib/ex_aws/config.ex
+++ b/lib/ex_aws/config.ex
@@ -122,8 +122,19 @@ defmodule ExAws.Config do
 
   def parse_host_for_region(config), do: config
 
-  def awscli_auth_adapter do
-    Application.get_env(:ex_aws, :awscli_auth_adapter, nil)
+  def awscli_auth_adapter, do: Application.get_env(:ex_aws, :awscli_auth_adapter, nil)
+
+  def awscli_auth_credentials(profile, credentials_ini_provider \\ ExAws.CredentialsIni.File) do
+    case Application.get_env(:ex_aws, :awscli_credentials, nil) do
+      nil ->
+        credentials_ini_provider.security_credentials(profile)
+
+      %{^profile => profile_credentials} ->
+        profile_credentials
+
+      _otherwise ->
+        raise("Missing #{profile} in provided credentials.")
+    end
   end
 
   defp valid_map_or_nil(map) when map == %{}, do: nil

--- a/lib/ex_aws/config/auth_cache.ex
+++ b/lib/ex_aws/config/auth_cache.ex
@@ -64,7 +64,7 @@ defmodule ExAws.Config.AuthCache do
   def refresh_awscli_config(profile, expiration, ets) do
     Process.send_after(self(), {:refresh_awscli_config, profile, expiration}, expiration)
 
-    auth = ExAws.CredentialsIni.security_credentials(profile)
+    auth = ExAws.Config.awscli_auth_credentials(profile)
 
     auth =
       case ExAws.Config.awscli_auth_adapter() do

--- a/lib/ex_aws/credentials_ini/file.ex
+++ b/lib/ex_aws/credentials_ini/file.ex
@@ -1,5 +1,5 @@
 if Code.ensure_loaded?(ConfigParser) do
-  defmodule ExAws.CredentialsIni do
+  defmodule ExAws.CredentialsIni.File do
     # as per https://docs.aws.amazon.com/cli/latest/topic/config-vars.html
     @valid_config_keys ~w(
       aws_access_key_id aws_secret_access_key aws_session_token region
@@ -83,7 +83,7 @@ if Code.ensure_loaded?(ConfigParser) do
     end
   end
 else
-  defmodule ExAws.CredentialsIni do
+  defmodule ExAws.CredentialsIni.File do
     def security_credentials(_), do: raise("ConfigParser required to use")
     def parse_ini_file(_, _), do: raise("ConfigParser required to use")
     def replace_token_key(_), do: raise("ConfigParser required to use")

--- a/lib/ex_aws/credentials_ini/provider.ex
+++ b/lib/ex_aws/credentials_ini/provider.ex
@@ -1,0 +1,12 @@
+defmodule ExAws.CredentialsIni.Provider do
+  @moduledoc """
+  Specifies expected behaviour of a credentials provider.
+
+  A credentials initializer provider is a module that fetches the AWS credentials from different sources.
+  """
+
+  @type profile :: String.t()
+  @type credentials :: map()
+
+  @callback security_credentials(profile) :: credentials
+end

--- a/test/ex_aws/config_test.exs
+++ b/test/ex_aws/config_test.exs
@@ -1,6 +1,14 @@
 defmodule ExAws.ConfigTest do
   use ExUnit.Case, async: true
 
+  setup do
+    Application.delete_env(:ex_aws, :awscli_credentials)
+
+    on_exit(fn ->
+      Application.delete_env(:ex_aws, :awscli_credentials)
+    end)
+  end
+
   test "overrides work properly" do
     config = ExAws.Config.new(:s3, region: "us-west-2")
     assert config.region == "us-west-2"
@@ -30,51 +38,56 @@ defmodule ExAws.ConfigTest do
            |> Map.get(:security_token) == value
   end
 
-  test "credentials file is parsed" do
-    example_credentials = """
-    [default]
-    aws_access_key_id     = TESTKEYID
-    aws_secret_access_key = TESTSECRET
-    aws_session_token     = TESTTOKEN
-    """
+  test "config file is parsed if no given credentials in configuraion" do
+    profile = "default"
 
-    credentials =
-      ExAws.CredentialsIni.parse_ini_file({:ok, example_credentials}, "default")
-      |> ExAws.CredentialsIni.replace_token_key()
+    Mox.expect(ExAws.Credentials.InitMock, :security_credentials, 1, fn ^profile ->
+      %{region: "eu-west-1"}
+    end)
 
-    assert credentials.access_key_id == "TESTKEYID"
-    assert credentials.secret_access_key == "TESTSECRET"
-    assert credentials.security_token == "TESTTOKEN"
-  end
-
-  test "{:system} in profile name gets dynamic profile name" do
-    System.put_env("AWS_PROFILE", "custom-profile")
-
-    example_credentials = """
-    [custom-profile]
-    aws_access_key_id     = TESTKEYID
-    aws_secret_access_key = TESTSECRET
-    aws_session_token     = TESTTOKEN
-    """
-
-    credentials =
-      ExAws.CredentialsIni.parse_ini_file({:ok, example_credentials}, :system)
-      |> ExAws.CredentialsIni.replace_token_key()
-
-    assert credentials.access_key_id == "TESTKEYID"
-    assert credentials.secret_access_key == "TESTSECRET"
-    assert credentials.security_token == "TESTTOKEN"
-  end
-
-  test "config file is parsed" do
-    example_config = """
-    [default]
-    region = eu-west-1
-    """
-
-    config = ExAws.CredentialsIni.parse_ini_file({:ok, example_config}, "default")
+    config = ExAws.Config.awscli_auth_credentials(profile, ExAws.Credentials.InitMock)
 
     assert config.region == "eu-west-1"
+  end
+
+  test "profile config returned if given credentials in configuration" do
+    profile = "default"
+
+    example_credentials = %{
+      "default" => %{
+        region: "eu-west-1"
+      }
+    }
+
+    Application.put_env(:ex_aws, :awscli_credentials, example_credentials)
+
+    Mox.expect(ExAws.Credentials.InitMock, :security_credentials, 0, fn ^profile ->
+      %{region: "eu-west-1"}
+    end)
+
+    config = ExAws.Config.awscli_auth_credentials(profile, ExAws.Credentials.InitMock)
+
+    assert config.region == "eu-west-1"
+  end
+
+  test "error on wrong credentials configuration" do
+    profile = "other"
+
+    example_credentials = %{
+      "default" => %{
+        region: "eu-west-1"
+      }
+    }
+
+    Application.put_env(:ex_aws, :awscli_credentials, example_credentials)
+
+    Mox.expect(ExAws.Credentials.InitMock, :security_credentials, 0, fn ^profile ->
+      %{region: "eu-west-1"}
+    end)
+
+    assert_raise RuntimeError, fn ->
+      ExAws.Config.awscli_auth_credentials(profile, ExAws.Credentials.InitMock)
+    end
   end
 
   test "region as a plain string" do

--- a/test/ex_aws/credentials_ini/file_test.exs
+++ b/test/ex_aws/credentials_ini/file_test.exs
@@ -1,0 +1,50 @@
+defmodule ExAws.CredentialsIni.File.FileTest do
+  use ExUnit.Case, async: true
+
+  test "credentials file is parsed" do
+    example_credentials = """
+    [default]
+    aws_access_key_id     = TESTKEYID
+    aws_secret_access_key = TESTSECRET
+    aws_session_token     = TESTTOKEN
+    """
+
+    credentials =
+      ExAws.CredentialsIni.File.parse_ini_file({:ok, example_credentials}, "default")
+      |> ExAws.CredentialsIni.File.replace_token_key()
+
+    assert credentials.access_key_id == "TESTKEYID"
+    assert credentials.secret_access_key == "TESTSECRET"
+    assert credentials.security_token == "TESTTOKEN"
+  end
+
+  test "{:system} in profile name gets dynamic profile name" do
+    System.put_env("AWS_PROFILE", "custom-profile")
+
+    example_credentials = """
+    [custom-profile]
+    aws_access_key_id     = TESTKEYID
+    aws_secret_access_key = TESTSECRET
+    aws_session_token     = TESTTOKEN
+    """
+
+    credentials =
+      ExAws.CredentialsIni.File.parse_ini_file({:ok, example_credentials}, :system)
+      |> ExAws.CredentialsIni.File.replace_token_key()
+
+    assert credentials.access_key_id == "TESTKEYID"
+    assert credentials.secret_access_key == "TESTSECRET"
+    assert credentials.security_token == "TESTTOKEN"
+  end
+
+  test "config file is parsed" do
+    example_config = """
+    [default]
+    region = eu-west-1
+    """
+
+    config = ExAws.CredentialsIni.File.parse_ini_file({:ok, example_config}, "default")
+
+    assert config.region == "eu-west-1"
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -6,5 +6,6 @@ Application.ensure_all_started(:jsx)
 Application.ensure_all_started(:bypass)
 
 Mox.defmock(ExAws.Request.HttpMock, for: ExAws.Request.HttpClient)
+Mox.defmock(ExAws.Credentials.InitMock, for: ExAws.CredentialsIni.Provider)
 
 ExUnit.start()


### PR DESCRIPTION
## Problem
In order to make `ex_aws` fully production-ready, we need to take into account the containerized applications that run, for example, over Kubernetes or Nomad. A typical configuration of secrets for this kind of application is by injection using environment variables. It is very common to restrict write permissions on the file system to avoid security problems also.

The aforementioned facts enter in conflict with the design of the STS module which resides on a file system file in order to assume a role for example.

## Proposed solution
I bring a proposal with implementation where I try to allow the injection of auth credentials by configuration, allowing the user to decide if using a file in the file system or not using the current design.

I also created the concept of `CredentialsIni.Provider` as I considered that it could be helpful for code injection and further features.

In order to make it works, I'll make use of the new function `ExAws.Config.awscli_auth_credentials/1` in the downstream `ex_aws_sts` library in this PR https://github.com/ex-aws/ex_aws_sts/pull/22.

The configuration could be like this:
```elixir
config :ex_aws,
  access_key_id: [{:awscli, "default", 30}],
  secret_access_key: [{:awscli, "default", 30}],
  awscli_auth_adapter: ExAws.STS.AuthCache.AssumeRoleCredentialsAdapter,
  awscli_credentials: %{
    "default" => %{
      role_arn: "",
      access_key_id: "",
      secret_access_key: "",
      source_profile: "default"
    }
  }
```
Please, let me know if it works for you or you have any improvement so we can release this and improve the library! Thanks.