### PR TITLE
Normalize path when using virtual host

### DIFF
--- a/lib/ex_aws/operation/s3.ex
+++ b/lib/ex_aws/operation/s3.ex
@@ -26,6 +26,7 @@ defmodule ExAws.Operation.S3 do
 
       url =
         operation
+        |> normalize_path()
         |> add_resource_to_params()
         |> ExAws.Request.Url.build(config)
 
@@ -61,6 +62,19 @@ defmodule ExAws.Operation.S3 do
     def add_bucket_to_path(operation, config) do
       path = Path.join(["/", operation.bucket, operation.path]) |> Path.expand()
       {operation |> Map.put(:path, path), config}
+    end
+
+    @spec normalize_path(operation :: ExAws.Operation.S3.t()) ::
+            ExAws.Operation.S3.t()
+    def normalize_path(operation) do
+      normalized_path =
+        if String.first(operation.path) === "/" do
+          operation.path
+        else
+          Path.join(["/", operation.path])
+        end
+
+      operation |> Map.put(:path, normalized_path)
     end
 
     @spec add_resource_to_params(operation :: ExAws.Operation.S3.t()) :: ExAws.Operation.S3.t()

--- a/lib/ex_aws/operation/s3.ex
+++ b/lib/ex_aws/operation/s3.ex
@@ -26,7 +26,7 @@ defmodule ExAws.Operation.S3 do
 
       url =
         operation
-        |> normalize_path()
+        |> ensure_absolute_path()
         |> add_resource_to_params()
         |> ExAws.Request.Url.build(config)
 
@@ -64,23 +64,12 @@ defmodule ExAws.Operation.S3 do
       {operation |> Map.put(:path, path), config}
     end
 
-    @spec normalize_path(operation :: ExAws.Operation.S3.t()) ::
-            ExAws.Operation.S3.t()
-    def normalize_path(operation) do
-      normalized_path =
-        if String.first(operation.path) === "/" do
-          operation.path
-        else
-          Path.join(["/", operation.path])
-        end
-
-      operation |> Map.put(:path, normalized_path)
-    end
-
     @spec add_resource_to_params(operation :: ExAws.Operation.S3.t()) :: ExAws.Operation.S3.t()
     def add_resource_to_params(operation) do
       params = operation.params |> Map.new() |> Map.put(operation.resource, 1)
       operation |> Map.put(:params, params)
     end
+
+    defp ensure_absolute_path(operation), do: put_in(operation.path, Path.join(["/", operation.path]))
   end
 end


### PR DESCRIPTION
Have encountered some issues after switching to virtual host style paths, namely this:

```
** (ArgumentError) :path in URI must be nil or an absolute path if :host or :authority are given, got: %URI{authority: nil, fragment: nil, host: "some-bucket-name.s3.amazonaws.com", path: "some-key", port: 443, query: "", scheme: "https", userinfo: nil}
    (elixir 1.10.2) lib/uri.ex:662: String.Chars.URI.to_string/1
    (ex_aws 2.1.7) lib/ex_aws/request/url.ex:16: ExAws.Request.Url.build/2
    (ex_aws 2.1.7) lib/ex_aws/operation/s3.ex:30: ExAws.Operation.ExAws.Operation.S3.perform/2
```

Traced it back to `ExAws.Operation.S3.add_bucket_to_path`. When using non-virtual host bucket paths, `add_bucket_to_path` will automatically prepend a forward slash to the path to make it absolute. This does not happen when using virtual host bucket paths.