### PR TITLE
Allow separate configuration of http_opts used for AWS metadata

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -35,3 +35,5 @@ config :ex_aws, :s3,
   scheme: "https://",
   host: "s3.amazonaws.com",
   region: "us-east-1"
+
+config :ex_aws, :metadata, http_opts: [pool: :ex_aws_metadata]

--- a/lib/ex_aws/instance_meta.ex
+++ b/lib/ex_aws/instance_meta.ex
@@ -12,9 +12,7 @@ defmodule ExAws.InstanceMeta do
   @task_role_root "http://169.254.170.2"
 
   def request(config, url) do
-    # Certain solutions like kube2iam will redirect instance meta requests,
-    # we need to follow those redirects.
-    case config.http_client.request(:get, url, "", [], follow_redirect: true) do
+    case config.http_client.request(:get, url, "", [], http_opts(config)) do
       {:ok, %{status_code: 200, body: body}} ->
         body
 
@@ -81,5 +79,17 @@ defmodule ExAws.InstanceMeta do
       security_token: result["Token"],
       expiration: result["Expiration"]
     }
+  end
+
+  defp http_opts(config) do
+    # Certain solutions like kube2iam will redirect instance meta requests,
+    # we need to follow those redirects.
+    defaults = [follow_redirect: true]
+
+    overrides =
+      Application.get_env(:ex_aws, :metadata, [])
+      |> Keyword.get(:http_opts)
+
+    Keyword.merge(defaults, overrides)
   end
 end

--- a/test/ex_aws/instance_meta_test.exs
+++ b/test/ex_aws/instance_meta_test.exs
@@ -20,4 +20,24 @@ defmodule ExAws.InstanceMetaTest do
 
     assert ExAws.InstanceMeta.instance_role(config) == role_name
   end
+
+  test "separate http opts for instance metadata" do
+    role_name = "dummy-role"
+
+    ExAws.Request.HttpMock
+    |> expect(:request, fn _method, _url, _body, _headers, opts ->
+      # configured in config/text.exs
+      assert Keyword.get(opts, :pool) == :ex_aws_metadata
+      {:ok, %{status_code: 200, body: role_name}}
+    end)
+
+    config =
+      ExAws.Config.new(:ec2,
+        http_client: ExAws.Request.HttpMock,
+        access_key_id: "dummy",
+        secret_access_key: "dummy"
+      )
+
+    assert ExAws.InstanceMeta.instance_role(config) == role_name
+  end
 end


### PR DESCRIPTION
It is possible to configure the HTTP client on per-service basis. However this is not possible when fetching AWS metadata (specifically, fetching IAM credentials from the EC2 instance role). This risks metadata requests competing for connections with other requests and can lead to starvation in extreme cases.

This PR is an attempt to enable providing configuration separately for metadata requests, like so:

```
config :ex_aws, :metadata,
  http_opts: [
    pool: :ex_aws_metadata
]
```

More context is here: https://github.com/ex-aws/ex_aws/issues/598