### PR TITLE
Relax requirement on Jason optional library to any 1.x version

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -36,7 +36,7 @@ defmodule ExAws.Mixfile do
       {:dialyxir, "~> 1.0", only: [:dev, :test], runtime: false},
       {:ex_doc, "~> 0.16", only: [:dev, :test]},
       {:hackney, "~> 1.9", optional: true},
-      {:jason, "~> 1.1", optional: true},
+      {:jason, "~> 1.0", optional: true},
       {:jsx, "~> 3.0", optional: true},
       {:mox, "~> 1.0", only: :test},
       {:sweet_xml, "~> 0.6", optional: true}


### PR DESCRIPTION
Hi there!

Despite the mix.lock file currently using Jason 1.2.2 the way mix.exs currently tags the minimum required version for Jason is causing our applications to run into dependency conflicts with other libraries that have Jason as a dependency even though we are using Jason independently of any libraries and have upgraded to 1.2.2.

This appears to relax the restriction while still allowing you to use the latest version.