### PR TITLE
Add us-west-1 to list of supported ses services.

### DIFF
--- a/priv/endpoints.exs
+++ b/priv/endpoints.exs
@@ -1551,6 +1551,7 @@
             "eu-west-2" => %{},
             "us-east-1" => %{},
             "us-east-2" => %{},
+            "us-west-1" => %{},
             "us-west-2" => %{},
             "ca-central-1" => %{},
             "sa-east-1" => %{}


### PR DESCRIPTION
What does this do?
-------------------

I was looking to send emails from my app and then I was running into the `<service> not supported in region <region> for partition aws` error as per this issue: https://github.com/ex-aws/ex_aws/issues/682

So this adds `us-west-1` as an option for sending emails.

Technical Considerations
-------------------------

- I *think* that `email` is the correct key in the configuration mapping (I was originally looking for `ses`).

- This is where I looked to see if `us-west-1` *should* be supported: https://docs.aws.amazon.com/general/latest/gr/ses.html

Happy to look in other places as well if that is not the best spot!