### PR TITLE
Fix lead time in auth next refresh calculation

### DIFF
--- a/lib/ex_aws/config/auth_cache.ex
+++ b/lib/ex_aws/config/auth_cache.ex
@@ -121,16 +121,14 @@ defmodule ExAws.Config.AuthCache do
 
   defp next_refresh_in(%{expiration: expiration}) do
     try do
-      time_to_expiration =
+      expires_in_ms =
         expiration
         |> NaiveDateTime.from_iso8601!()
-        |> NaiveDateTime.diff(NaiveDateTime.utc_now())
+        |> NaiveDateTime.diff(NaiveDateTime.utc_now(), :millisecond)
 
-      expires_in_ms = max(0, 1000 * time_to_expiration)
-
-      # check either when it expires, or lead_time before that
-      # whichever is longer
-      max(expires_in_ms, expires_in_ms - @refresh_lead_time)
+      # refresh lead_time before auth expires, unless the time has passed
+      # otherwise refresh needed now
+      max(0, expires_in_ms - @refresh_lead_time)
     rescue
       _e -> 0
     end


### PR DESCRIPTION
The current auth refresh time calculation

```elixir
max(expires_in_ms, expires_in_ms - @refresh_lead_time)
```

will always result in the auth being refreshed at the moment it expires rather than `lead_time` before expiration since `@refresh_lead_time` is positive. I believe the intention of this function is to return the ms to `lead_time`, unless it's negative and otherwise return 0 - meaning refresh now.