### PR TITLE
make :http_opts for AWS metadata requests optional

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -35,5 +35,3 @@ config :ex_aws, :s3,
   scheme: "https://",
   host: "s3.amazonaws.com",
   region: "us-east-1"
-
-config :ex_aws, :metadata, http_opts: [pool: :ex_aws_metadata]

--- a/lib/ex_aws/instance_meta.ex
+++ b/lib/ex_aws/instance_meta.ex
@@ -88,7 +88,7 @@ defmodule ExAws.InstanceMeta do
 
     overrides =
       Application.get_env(:ex_aws, :metadata, [])
-      |> Keyword.get(:http_opts)
+      |> Keyword.get(:http_opts, [])
 
     Keyword.merge(defaults, overrides)
   end

--- a/test/ex_aws/instance_meta_test.exs
+++ b/test/ex_aws/instance_meta_test.exs
@@ -1,5 +1,5 @@
 defmodule ExAws.InstanceMetaTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   import Mox
 
@@ -21,23 +21,39 @@ defmodule ExAws.InstanceMetaTest do
     assert ExAws.InstanceMeta.instance_role(config) == role_name
   end
 
-  test "separate http opts for instance metadata" do
-    role_name = "dummy-role"
+  describe "metadata options" do
+    setup %{metadata_opts: metadata_opts} do
+      metadata_opts_old = Application.get_env(:ex_aws, :metadata, nil)
+      on_exit(fn ->
+        case metadata_opts_old do
+          nil ->
+            Application.delete_env(:ex_aws, :metadata)
+          _other ->
+            Application.put_env(:ex_aws, :metadata, metadata_opts_old)
+        end
+      end)
 
-    ExAws.Request.HttpMock
-    |> expect(:request, fn _method, _url, _body, _headers, opts ->
-      # configured in config/text.exs
-      assert Keyword.get(opts, :pool) == :ex_aws_metadata
-      {:ok, %{status_code: 200, body: role_name}}
-    end)
+      Application.put_env(:ex_aws, :metadata, metadata_opts)
+    end
 
-    config =
-      ExAws.Config.new(:ec2,
-        http_client: ExAws.Request.HttpMock,
-        access_key_id: "dummy",
-        secret_access_key: "dummy"
-      )
+    @tag metadata_opts: [http_opts: [pool: :ex_aws_metadata]]
+    test "separate http opts for instance metadata" do
+      role_name = "dummy-role"
 
-    assert ExAws.InstanceMeta.instance_role(config) == role_name
+      ExAws.Request.HttpMock
+      |> expect(:request, fn _method, _url, _body, _headers, opts ->
+        assert Keyword.get(opts, :pool) == :ex_aws_metadata
+        {:ok, %{status_code: 200, body: role_name}}
+      end)
+
+      config =
+        ExAws.Config.new(:ec2,
+          http_client: ExAws.Request.HttpMock,
+          access_key_id: "dummy",
+          secret_access_key: "dummy"
+        )
+
+      assert ExAws.InstanceMeta.instance_role(config) == role_name
+    end
   end
 end


### PR DESCRIPTION
The change in 01fad68 introduced a new required parameter