### PR TITLE
fix: `nil` default value in `InstanceMeta.http_opts/0`

### DIFF
--- a/lib/ex_aws/instance_meta.ex
+++ b/lib/ex_aws/instance_meta.ex
@@ -88,7 +88,7 @@ defmodule ExAws.InstanceMeta do
 
     overrides =
       Application.get_env(:ex_aws, :metadata, [])
-      |> Keyword.get(:http_opts)
+      |> Keyword.get(:http_opts, [])
 
     Keyword.merge(defaults, overrides)
   end


### PR DESCRIPTION
Unfortunately `Keyword.get(:http_opts)` on line 91 means that the `overrides` variable is `nil` when the `http_opts` configuration is not present, causing a backtrace:

```
** (FunctionClauseError) no function clause matching in Keyword.merge/2
   (elixir 1.10.4) lib/keyword.ex:703: Keyword.merge([follow_redirect: true], nil)
   (ex_aws 2.2.0) lib/ex_aws/instance_meta.ex:15: ExAws.InstanceMeta.request/2
   (ex_aws 2.2.0) lib/ex_aws/instance_meta.ex:64: ExAws.InstanceMeta.instance_role_credentials/1
   (ex_aws 2.2.0) lib/ex_aws/instance_meta.ex:72: ExAws.InstanceMeta.security_credentials/1
   (ex_aws 2.2.0) lib/ex_aws/config/auth_cache.ex:116: ExAws.Config.AuthCache.refresh_auth_now/2
   (ex_aws 2.2.0) lib/ex_aws/config/auth_cache.ex:45: ExAws.Config.AuthCache.handle_call/3
```