### PR TITLE
add "af-south-1" to S3 region in EX_AWS

### DIFF
--- a/priv/endpoints.exs
+++ b/priv/endpoints.exs
@@ -1267,6 +1267,10 @@
               "hostname" => "s3.ap-southeast-2.amazonaws.com",
               "signatureVersions" => ["s3", "s3v4"]
             },
+            "af-south-1" => %{
+              "hostname" => "s3.af-south-1.amazonaws.com",
+              "signatureVersions" => ["s3", "s3v4"]
+            },
             "ca-central-1" => %{},
             "eu-central-1" => %{},
             "eu-west-1" => %{


### PR DESCRIPTION
Was getting an error when trying to do operations of files in S3 inside the South Africa (af-south-1) region:

`** (RuntimeError) s3 not supported in region af-south-1 for partition aws`

Noticed the region wasn't added to the endpoints file for S3.