### PR TITLE
Add telemetry events to all requests

### DIFF
--- a/lib/ex_aws.ex
+++ b/lib/ex_aws.ex
@@ -52,9 +52,11 @@ defmodule ExAws do
 
   ## Telemetry events
 
-  ### `[:ex_aws, :request]`
+  The following events are published:
 
-  This event is invoked on every request sent to the aws.
+  * `[:ex_aws, :request, :start]` - dispatched on start every request sent to the AWS.
+  * `[:ex_aws, :request, :stop]` - dispatched on every response from AWS.
+  * `[:ex_aws, :request, :exception]` - dispatched after exceptions on request sent to AWS.
 
   With `:metadata` map including the following fields:
 

--- a/lib/ex_aws.ex
+++ b/lib/ex_aws.ex
@@ -19,6 +19,12 @@ defmodule ExAws do
   This is useful if you want to have certain configuration changed on a per
   request basis.
 
+  Also you can configure telemetry metrics with:
+
+    * `:telemetry_event` - The telemetry event name to dispatch the event under.
+      Defaults to `[:ex_aws, :request]`.
+    * `:telemetry_options` - Extra options to attach to telemetry event name.
+
   ## Examples
 
   If you have one of the service modules installed, you can just use those service

--- a/lib/ex_aws.ex
+++ b/lib/ex_aws.ex
@@ -50,6 +50,19 @@ defmodule ExAws do
 
       ExAws.request(op)
 
+  ## Telemetry events
+
+  ### `[:ex_aws, :request]`
+
+  This event is invoked on every request sent to the aws.
+
+  With `:metadata` map including the following fields:
+
+    * `:result` - the request result: `:ok` or `:error`
+    * `:attempt` - the attempt number
+    * `:options` - extra options given to the repo operation under
+      `:telemetry_options`
+
   """
   @impl ExAws.Behaviour
   def request(op, config_overrides \\ []) do

--- a/lib/ex_aws/config.ex
+++ b/lib/ex_aws/config.ex
@@ -15,7 +15,9 @@ defmodule ExAws.Config do
     :region,
     :security_token,
     :retries,
-    :normalize_path
+    :normalize_path,
+    :telemetry_event,
+    :telemetry_options
   ]
 
   @type t :: %{} | Keyword.t()
@@ -66,6 +68,12 @@ defmodule ExAws.Config do
 
       {:http_opts, http_opts}, config ->
         Map.put(config, :http_opts, http_opts)
+
+      {:telemetry_event, telemetry_event}, config ->
+        Map.put(config, :telemetry_event, telemetry_event)
+
+      {:telemetry_options, telemetry_options}, config ->
+        Map.put(config, :telemetry_options, telemetry_options)
 
       {k, v}, config ->
         case retrieve_runtime_value(v, config) do

--- a/lib/ex_aws/request.ex
+++ b/lib/ex_aws/request.ex
@@ -39,13 +39,7 @@ defmodule ExAws.Request do
         )
       end
 
-      case config[:http_client].request(
-             method,
-             safe_url,
-             req_body,
-             full_headers,
-             Map.get(config, :http_opts, [])
-           ) do
+      case do_request(config, method, safe_url, req_body, full_headers, attempt) do
         {:ok, %{status_code: status} = resp} when status in 200..299 or status == 304 ->
           {:ok, resp}
 
@@ -102,6 +96,31 @@ defmodule ExAws.Request do
           )
       end
     end
+  end
+
+  defp do_request(config, method, safe_url, req_body, full_headers, attempt) do
+    telemetry_event = Map.get(config, :telemetry_event, [:ex_aws, :request])
+    telemetry_options = Map.get(config, :telemetry_options, [])
+    telemetry_metadata = %{options: telemetry_options, attempt: attempt}
+
+    :telemetry.span(telemetry_event, telemetry_metadata, fn ->
+      config[:http_client].request(
+        method,
+        safe_url,
+        req_body,
+        full_headers,
+        Map.get(config, :http_opts, [])
+      )
+      |> case do
+        {:ok, %{status_code: status}} = result when status in 200..299 or status == 304 ->
+          telemetry_metadata = Map.put(telemetry_metadata, :result, :ok)
+          {result, telemetry_metadata}
+
+        result ->
+          telemetry_metadata = Map.put(telemetry_metadata, :result, :error)
+          {result, telemetry_metadata}
+      end
+    end)
   end
 
   def client_error(%{status_code: status, body: body} = error, json_codec) do

--- a/mix.exs
+++ b/mix.exs
@@ -31,6 +31,7 @@ defmodule ExAws.Mixfile do
 
   defp deps() do
     [
+      {:telemetry, "~> 0.4"},
       {:bypass, "~> 2.1", only: :test},
       {:configparser_ex, "~> 4.0", optional: true},
       {:dialyxir, "~> 1.0", only: [:dev, :test], runtime: false},

--- a/test/ex_aws/ex_aws_test.exs
+++ b/test/ex_aws/ex_aws_test.exs
@@ -21,6 +21,8 @@ defmodule ExAwsTest do
   end
 
   test "basic json operation works" do
+    TelemetryHelper.attach_telemetry([:ex_aws, :request])
+
     op = %ExAws.Operation.JSON{
       http_method: :post,
       service: :dynamodb,
@@ -31,6 +33,19 @@ defmodule ExAwsTest do
     }
 
     assert {:ok, %{"TableNames" => _}} = ExAws.request(op)
+
+    assert_receive {[:ex_aws, :request, :start], %{system_time: _},
+                    %{
+                      attempt: 1,
+                      options: []
+                    }}
+
+    assert_receive {[:ex_aws, :request, :stop], %{duration: _},
+                    %{
+                      options: [],
+                      attempt: 1,
+                      result: :ok
+                    }}
   end
 
   test "json operation with differently named service" do
@@ -50,5 +65,63 @@ defmodule ExAwsTest do
     }
 
     assert {:ok, %{"Streams" => _}} = ExAws.request(op)
+  end
+
+  test "custom telemetry options" do
+    TelemetryHelper.attach_telemetry([:ex_aws, :custom_request])
+
+    op = %ExAws.Operation.JSON{
+      http_method: :post,
+      service: :dynamodb,
+      headers: [
+        {"x-amz-target", "DynamoDB_20120810.ListTables"},
+        {"content-type", "application/x-amz-json-1.0"}
+      ]
+    }
+
+    options = [telemetry_event: [:ex_aws, :custom_request], telemetry_options: [name: :sample]]
+
+    assert {:ok, %{"TableNames" => _}} = ExAws.request(op, options)
+
+    assert_receive {[:ex_aws, :custom_request, :start], %{system_time: _},
+                    %{
+                      attempt: 1,
+                      options: [name: :sample]
+                    }}
+
+    assert_receive {[:ex_aws, :custom_request, :stop], %{duration: _},
+                    %{
+                      options: [name: :sample],
+                      attempt: 1,
+                      result: :ok
+                    }}
+  end
+
+  test "invalid request" do
+    TelemetryHelper.attach_telemetry([:ex_aws, :request])
+
+    op = %ExAws.Operation.JSON{
+      http_method: :post,
+      service: :dynamodb,
+      headers: [
+        {"x-amz-target", "DynamoDB_20120810.CreateTable"},
+        {"content-type", "application/x-amz-json-1.0"}
+      ]
+    }
+
+    assert {:error, {"ValidationException", _}} = ExAws.request(op)
+
+    assert_receive {[:ex_aws, :request, :start], %{system_time: _},
+                    %{
+                      options: [],
+                      attempt: 1
+                    }}
+
+    assert_receive {[:ex_aws, :request, :stop], %{duration: _},
+                    %{
+                      options: [],
+                      attempt: 1,
+                      result: :error
+                    }}
   end
 end

--- a/test/ex_aws/request_test.exs
+++ b/test/ex_aws/request_test.exs
@@ -26,6 +26,8 @@ defmodule ExAws.RequestTest do
   end
 
   test "301 redirect", context do
+    TelemetryHelper.attach_telemetry([:ex_aws, :request])
+
     ExAws.Request.HttpMock
     |> expect(:request, fn _method, _url, _body, _headers, _opts -> {:ok, %{status_code: 301}} end)
 
@@ -46,6 +48,19 @@ defmodule ExAws.RequestTest do
                         {:attempt, 1}
                       )
            end) =~ "Received redirect, did you specify the correct region?"
+
+    assert_receive {[:ex_aws, :request, :start], %{system_time: _},
+                    %{
+                      options: [],
+                      attempt: 1
+                    }}
+
+    assert_receive {[:ex_aws, :request, :stop], %{duration: _},
+                    %{
+                      options: [],
+                      attempt: 1,
+                      result: :error
+                    }}
   end
 
   test "handles encoding S3 URLs with params", context do
@@ -53,6 +68,8 @@ defmodule ExAws.RequestTest do
     url = "https://examplebucket.s3.amazonaws.com/test hello #3.txt?acl=21"
     service = :s3
     request_body = ""
+
+    TelemetryHelper.attach_telemetry([:ex_aws, :request])
 
     expect(
       ExAws.Request.HttpMock,
@@ -73,6 +90,19 @@ defmodule ExAws.RequestTest do
                request_body,
                {:attempt, 1}
              )
+
+    assert_receive {[:ex_aws, :request, :start], %{system_time: _},
+                    %{
+                      options: [],
+                      attempt: 1
+                    }}
+
+    assert_receive {[:ex_aws, :request, :stop], %{duration: _},
+                    %{
+                      options: [],
+                      attempt: 1,
+                      result: :ok
+                    }}
   end
 
   test "handles encoding S3 URLs without params", context do
@@ -109,6 +139,8 @@ defmodule ExAws.RequestTest do
     success =
       "{\"SequenceNumber\":\"49592207023850419758877078054930583111417627497740632066\",\"ShardId\":\"shardId-000000000000\"}"
 
+    TelemetryHelper.attach_telemetry([:ex_aws, :request])
+
     ExAws.Request.HttpMock
     |> expect(:request, 2, fn _method, _url, _body, _headers, _opts ->
       {:ok, %{status_code: 400, body: exception}}
@@ -132,5 +164,12 @@ defmodule ExAws.RequestTest do
                request_body,
                {:attempt, 1}
              )
+
+    assert_receive {[:ex_aws, :request, :start], %{system_time: _}, %{attempt: 1}}
+    assert_receive {[:ex_aws, :request, :stop], %{duration: _}, %{attempt: 1, result: :error}}
+    assert_receive {[:ex_aws, :request, :start], %{system_time: _}, %{attempt: 2}}
+    assert_receive {[:ex_aws, :request, :stop], %{duration: _}, %{attempt: 2, result: :error}}
+    assert_receive {[:ex_aws, :request, :start], %{system_time: _}, %{attempt: 3}}
+    assert_receive {[:ex_aws, :request, :stop], %{duration: _}, %{attempt: 3, result: :ok}}
   end
 end

--- a/test/telemetry_helper.exs
+++ b/test/telemetry_helper.exs
@@ -1,0 +1,26 @@
+defmodule TelemetryHelper do
+  alias ExUnit.Callbacks
+
+  def attach_telemetry(prefix) do
+    name = "ex_aws_test"
+    parent_pid = self()
+
+    :ok =
+      :telemetry.attach_many(
+        name,
+        [
+          prefix ++ [:start],
+          prefix ++ [:stop],
+          prefix ++ [:exception]
+        ],
+        fn path, args, metadata, _config ->
+          send(parent_pid, {path, args, metadata})
+        end,
+        nil
+      )
+
+    Callbacks.on_exit(fn ->
+      :telemetry.detach(name)
+    end)
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,5 +1,6 @@
 Code.require_file("default_helper.exs", __DIR__)
 Code.require_file("alternate_helper.exs", __DIR__)
+Code.require_file("telemetry_helper.exs", __DIR__)
 
 Application.ensure_all_started(:hackney)
 Application.ensure_all_started(:jsx)


### PR DESCRIPTION
As mentioned [here](https://github.com/ex-aws/ex_aws/issues/661).

> It would allow users of this library to capture important metrics and send them to their monitoring solution. This way, we save everyone the time to instrument their own usage of this library.