### PR TITLE
Bump readme configparser_ex version

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ This means it will try to resolve credentials in order:
 AWS CLI config files are supported, but require an additional dependency:
 
 ```elixir
-{:configparser_ex, "~> 2.0"}
+{:configparser_ex, "~> 4.0"}
 ```
 
 You can then add `{:awscli, "profile_name", timeout}` to the above config and


### PR DESCRIPTION
The latest version of `ex_aws` requires `configparser_ex` 4.0
Currently, following the readme results in this error message:
```
Failed to use "configparser_ex" because
  ex_aws (version 2.2.3) requires ~> 4.0
  mix.exs specifies ~> 2.0
  ```