### PR TITLE
Replaces pattern-matching by regex to remove leading duplicate spaces on auth request headers

### DIFF
--- a/lib/ex_aws/auth.ex
+++ b/lib/ex_aws/auth.ex
@@ -192,8 +192,11 @@ defmodule ExAws.Auth do
     |> IO.iodata_to_binary()
   end
 
-  def remove_dup_spaces(""), do: ""
-  def remove_dup_spaces(<<value::binary>>), do: Regex.replace(~r/^\s+/, value, " ")
+  defp remove_dup_spaces(str), do: remove_dup_spaces(str, "")
+  defp remove_dup_spaces(str, str), do: str
+
+  defp remove_dup_spaces(str, _last),
+    do: str |> String.replace("  ", " ") |> remove_dup_spaces(str)
 
   defp string_to_sign(request, service, datetime, config) do
     request = hash_sha256(request)

--- a/lib/ex_aws/auth.ex
+++ b/lib/ex_aws/auth.ex
@@ -192,12 +192,8 @@ defmodule ExAws.Auth do
     |> IO.iodata_to_binary()
   end
 
-  defp remove_dup_spaces(""), do: ""
-  defp remove_dup_spaces("  " <> rest), do: remove_dup_spaces(" " <> rest)
-
-  defp remove_dup_spaces(<<char::binary-1, rest::binary>>) do
-    char <> remove_dup_spaces(rest)
-  end
+  def remove_dup_spaces(""), do: ""
+  def remove_dup_spaces(<<value::binary>>), do: Regex.replace(~r/^\s+/, value, " ")
 
   defp string_to_sign(request, service, datetime, config) do
     request = hash_sha256(request)


### PR DESCRIPTION
When executing some profiles on services that uses ex_aws, for low CPU resource services, on of the main performance issues is the way this code is replacing the leading duplicate spaces.

To avoid this type of performance issue, this PR aims to replace the pattern matching code style by a regex match/replace mechanism.