### PR TITLE
LICENSE file into hexpm

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -47,7 +47,7 @@ defmodule ExAws.Mixfile do
   defp package do
     [
       description: description(),
-      files: ["priv", "lib", "config", "mix.exs", "README*"],
+      files: ["priv", "lib", "config", "mix.exs", "README*, LICENSE"],
       maintainers: ["Bernard Duggan", "Ben Wilson"],
       licenses: ["MIT"],
       links: %{

--- a/mix.exs
+++ b/mix.exs
@@ -47,7 +47,7 @@ defmodule ExAws.Mixfile do
   defp package do
     [
       description: description(),
-      files: ["priv", "lib", "config", "mix.exs", "README*, LICENSE"],
+      files: ["priv", "lib", "config", "mix.exs", "README*", "LICENSE"],
       maintainers: ["Bernard Duggan", "Ben Wilson"],
       licenses: ["MIT"],
       links: %{


### PR DESCRIPTION
Also I there's a license in `mix.exs` stated, I think it's better to also copy the LICENSE file into hexpm for better automatic license detection