### PR TITLE
Return expected sequence token as part of error result

### DIFF
--- a/test/ex_aws/request_test.exs
+++ b/test/ex_aws/request_test.exs
@@ -133,4 +133,32 @@ defmodule ExAws.RequestTest do
                {:attempt, 1}
              )
   end
+
+  test "Expected sequence token is provided", context do
+    exception =
+      "{\"__type\": \"InvalidSequenceTokenException\", \"message\": \"The given sequenceToken is invalid. The next expected sequenceToken is: 49616449618992442982853194240983586320797062450229805234\", \"expectedSequenceToken\": \"49616449618992442982853194240983586320797062450229805234\"}"
+
+    ExAws.Request.HttpMock
+    |> expect(:request, fn _method, _url, _body, _headers, _opts ->
+      {:ok, %{status_code: 400, body: exception}}
+    end)
+
+    http_method = :post
+    url = "https://kinesis.aws.com/"
+    service = :kinesis
+    request_body = ""
+
+    assert {:error,
+            {"InvalidSequenceTokenException", _,
+             "49616449618992442982853194240983586320797062450229805234"}} =
+             ExAws.Request.request_and_retry(
+               http_method,
+               url,
+               service,
+               context[:config],
+               context[:headers],
+               request_body,
+               {:attempt, 1}
+             )
+  end
 end


### PR DESCRIPTION
After https://github.com/ex-aws/ex_aws/commit/ed5d8ce628cf06951fb89e2a49a0c26c57af861d# a breaking change was introduced. 
Before this, exceptions like DataAlreadyAcceptedException and InvalidSequenceTokenException produced errors that contained the expected sequence token and it could be directly used from the error map itself. Currently, errors are of the format `{:error, {type, message}}`, with the message containing the expected sequence token. To avoid parsing that error message, we can provide that token directly, like `{:error, {type, message, token}}` for the types of errors that contain this token.
I've also looked at the possibility of just having `{:error, reason}` where reason is the whole map returned by aws, containing the error type, message, and any other data like the token, but this would have broken too many clients.
This is still a breaking change, but it seems like the least invasive one.