### PR TITLE
Tighten telemetry requirement

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,10 @@ Unfortunately however my own (Ben Wilson) efforts at this keep hitting dead ends
 
 For now, it's been simply easier to build helper modules by hand. Who knows, maybe you're up for building ExAws v3.0?
 
+## Formatting and code style
+
+Before opening a PR, please run `mix format` over your changes with a recent Elixir version, and also `mix dialyzer` to make sure you haven't introduced any typing errors.
+
 ## Running Tests
 Running the test suite for ex_aws requires a few things:
 

--- a/mix.exs
+++ b/mix.exs
@@ -31,7 +31,7 @@ defmodule ExAws.Mixfile do
 
   defp deps() do
     [
-      {:telemetry, "~> 0.4"},
+      {:telemetry, "~> 0.4.3"},
       {:bypass, "~> 2.1", only: :test},
       {:configparser_ex, "~> 4.0", optional: true},
       {:dialyxir, "~> 1.0", only: [:dev, :test], runtime: false},


### PR DESCRIPTION
Turns out telemetry 0.4.0 doesn't include the `span` function.
Also add a comment about formatting contributions.

Resolves #794 