### PR TITLE
fix: prevent unrelated `awscli` config from leaking

### DIFF
--- a/lib/ex_aws/config.ex
+++ b/lib/ex_aws/config.ex
@@ -77,7 +77,7 @@ defmodule ExAws.Config do
 
       {k, v}, config ->
         case retrieve_runtime_value(v, config) do
-          %{} = result -> Map.merge(config, result)
+          %{} = result -> Map.put(config, k, result[k])
           value -> Map.put(config, k, value)
         end
     end)


### PR DESCRIPTION
Here's a simple config setup:

```elixir
# config.exs

config :ex_aws,
  region: "us-east-1",
  access_key_id: {:awscli, "default", 30},
  secret_access_key: {:awscli, "default", 30}
```

```toml
# ~/.aws/config

[default]
region = "us-west-2"
```

I would expect `ExAws.Config.new(:s3)` to return a config where `region` is `"us-east-1"`, but it incorrectly returns `region: "us-west-2"` (all values configured in `~/.aws/{config, credentials}` take precedence over any other configured values, even if their keys aren't specified).

This PR modifies `ExAws.Config.retrieve_runtime_config/1` to only set the requested key(s), instead of merging in all available values.

Resolves #521.