### PR TITLE
Fix README codec section

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,11 +129,11 @@ config :ex_aws,
 
 ### JSON Codec Configuration
 
-The default JSON codec is Poison.  You can choose a different one:
+The default JSON codec is Jason.  You can choose a different one:
 
 ```elixir
 config :ex_aws,
-  json_codec: Jason
+  json_codec: Poison
 ```
 
 ### Path Normalization


### PR DESCRIPTION
It claims the default JSON codec to be Poison.

It was changed into Jason in commit https://github.com/ex-aws/ex_aws/commit/efd3b660f2471ddbf6dc87e7269745a41500456c
2 years ago.