### PR TITLE
Revert "prevent unrelated awscli config from leaking"

### DIFF
--- a/lib/ex_aws/config.ex
+++ b/lib/ex_aws/config.ex
@@ -77,7 +77,7 @@ defmodule ExAws.Config do
 
       {k, v}, config ->
         case retrieve_runtime_value(v, config) do
-          %{} = result -> Map.put(config, k, result[k])
+          %{} = result -> Map.merge(config, result)
           value -> Map.put(config, k, value)
         end
     end)


### PR DESCRIPTION
This reverts commit b6dd414bdd0c30ff54627ca399622fc10a1ad5f3.
Reverts #796.
Resolves #814.