### PR TITLE
Pass Headers to Request

### DIFF
--- a/lib/ex_aws/operation/rest_query.ex
+++ b/lib/ex_aws/operation/rest_query.ex
@@ -12,7 +12,7 @@ end
 
 defimpl ExAws.Operation, for: ExAws.Operation.RestQuery do
   def perform(operation, config) do
-    headers = []
+    headers = config[:headers] || []
     url = ExAws.Request.Url.build(operation, config)
 
     ExAws.Request.request(


### PR DESCRIPTION
This change allows HTTP headers to be passed in. This was originally questioned when it was merged in here: https://github.com/ex-aws/ex_aws/pull/286#discussion_r90781530 but wasn't necessary for the use case at the time. However, attempting to use this with Cloudfront (and presumably any other service that utilizes ETag) makes this necessary.

This should add Headers if present, otherwise, leave them as an empty array. So, there should be no functional impact for existing users of this method.