### PR TITLE
Add config for sagemaker_runtime_a2i

### DIFF
--- a/lib/ex_aws/config/defaults.ex
+++ b/lib/ex_aws/config/defaults.ex
@@ -39,6 +39,11 @@ defmodule ExAws.Config.Defaults do
     |> Map.merge(defaults(:sagemaker))
   end
 
+  def defaults(:sagemaker_runtime_a2i) do
+    %{service_override: :sagemaker}
+    |> Map.merge(defaults(:sagemaker))
+  end
+
   def defaults(:iot_data) do
     %{service_override: :iotdata}
     |> Map.merge(defaults(:iot))
@@ -95,6 +100,7 @@ defmodule ExAws.Config.Defaults do
 
   defp service_map(:ses), do: "email"
   defp service_map(:sagemaker_runtime), do: "runtime.sagemaker"
+  defp service_map(:sagemaker_runtime_a2i), do: "a2i-runtime.sagemaker"
   defp service_map(:lex_runtime), do: "runtime.lex"
   defp service_map(:lex_models), do: "models.lex"
   defp service_map(:dynamodb_streams), do: "streams.dynamodb"

--- a/priv/endpoints.exs
+++ b/priv/endpoints.exs
@@ -1218,6 +1218,22 @@
             "sa-east-1" => %{}
           }
         },
+        "a2i-runtime.sagemaker" => %{
+          "endpoints" => %{
+            "us-east-2" => %{},
+            "us-east-1" => %{},
+            "us-west-2" => %{},
+            "ap-south-1" => %{},
+            "ap-northeast-2" => %{},
+            "ap-southeast-1" => %{},
+            "ap-southeast-2" => %{},
+            "ap-northeast-1" => %{},
+            "ca-central-1" => %{},
+            "eu-central-1" => %{},
+            "eu-west-1" => %{},
+            "eu-west-2" => %{}
+          }
+        },
         "cloudhsm" => %{
           "endpoints" => %{
             "ap-northeast-1" => %{},


### PR DESCRIPTION
To allow ex_aws to be used with the Amazon Augmented AI API (endpoint
`a2i-runtime.sagemaker.REGION.amazonaws.com`) a new service map override
has been added named `:sagemaker_runtime_a2i` to reflect the existing
`:sagemaker_runtime`

https://docs.aws.amazon.com/augmented-ai/2019-11-07/APIReference/API_StartHumanLoop.html

Example:

```
operation =
  %ExAws.Operation.JSON{
    http_method: :get,
    path: "/human-loops",
    service: :sagemaker_runtime_a2i
}

ExAws.request(operation)
```