### PR TITLE
Support passing headers

### DIFF
--- a/lib/ex_aws/config.ex
+++ b/lib/ex_aws/config.ex
@@ -74,7 +74,7 @@ defmodule ExAws.Config do
 
       {:telemetry_options, telemetry_options}, config ->
         Map.put(config, :telemetry_options, telemetry_options)
-        
+
       {:headers, headers}, config ->
         Map.put(config, :headers, headers)
 

--- a/lib/ex_aws/config.ex
+++ b/lib/ex_aws/config.ex
@@ -74,6 +74,9 @@ defmodule ExAws.Config do
 
       {:telemetry_options, telemetry_options}, config ->
         Map.put(config, :telemetry_options, telemetry_options)
+        
+      {:headers, headers}, config ->
+        Map.put(config, :headers, headers)
 
       {k, v}, config ->
         case retrieve_runtime_value(v, config) do

--- a/test/ex_aws/config_test.exs
+++ b/test/ex_aws/config_test.exs
@@ -106,4 +106,11 @@ defmodule ExAws.ConfigTest do
            |> ExAws.Config.new(region: {:system, "AWS_REGION"})
            |> Map.get(:region) == region_value
   end
+
+  test "headers are passed as provided" do
+    headers = [{ "If-Match", "ABC" }]
+    assert :s3
+           |> ExAws.Config.new(headers: headers )
+           |> Map.get(:headers) == headers
+  end
 end

--- a/test/ex_aws/config_test.exs
+++ b/test/ex_aws/config_test.exs
@@ -108,9 +108,10 @@ defmodule ExAws.ConfigTest do
   end
 
   test "headers are passed as provided" do
-    headers = [{ "If-Match", "ABC" }]
+    headers = [{"If-Match", "ABC"}]
+
     assert :s3
-           |> ExAws.Config.new(headers: headers )
+           |> ExAws.Config.new(headers: headers)
            |> Map.get(:headers) == headers
   end
 end


### PR DESCRIPTION
Passing Headers, such as `If-Match`, was previously causing issues. This is because the following code was executing when passing an array of header values:

```elixir
  def retrieve_runtime_value(values, config) when is_list(values) do
    values
    |> Stream.map(&retrieve_runtime_value(&1, config))
    |> Enum.find(& &1)
  end
```

which destructured the data from `[{ "header-name", "header-value"}]` to `{ "header-name", "header-value"}` (note that it is no longer a list containing a tuple, but rather simply a tuple.

This caused issues later when trying to build up the headers to send in the request. Abbreviated for simplicity, we had:

```elixir
headers = { "some-key", "some-value" }
headers = [ defaultHeaders | headers ]
```

Because `headers` was no longer a `List`, the `headers` variable now contains an improper List.

This change passes `config.headers` through to the underlying functions without destructuring it first.