### PR TITLE
Adding new supported endpoints for Rekognition

### DIFF
--- a/priv/endpoints.exs
+++ b/priv/endpoints.exs
@@ -1279,12 +1279,17 @@
         },
         "rekognition" => %{
           "endpoints" => %{
+            "ap-south-1" => %{},
             "ap-northeast-1" => %{},
+            "ap-northeast-2" => %{},
             "ap-southeast-1" => %{},
             "ap-southeast-2" => %{},
+            "ca-central-1" => %{},
+            "eu-central-1" => %{},
             "eu-west-1" => %{},
             "us-east-1" => %{},
             "us-east-2" => %{},
+            "us-west-1" => %{},
             "us-west-2" => %{}
           }
         },


### PR DESCRIPTION
## Description
Noticed we were getting some errors for `rekognition not supported in region for partition aws`. Although, the specified region was supported according to the AWS documentation.
 
I've added the new supported endpoints: ap-south-1, ap-northeast-2, ca-central-1, eu-central-1, and us-west-1 for Rekognition following Amazons documentation: https://docs.aws.amazon.com/general/latest/gr/rekognition.html

![Screen Shot 2021-10-18 at 9 48 39 AM](https://user-images.githubusercontent.com/84341324/137785544-4b352c49-655c-4be5-a4d8-f3ce273959da.png)

