### PR TITLE
Use '?\s' instead of '?\ '

### DIFF
--- a/lib/ex_aws/request/url.ex
+++ b/lib/ex_aws/request/url.ex
@@ -108,7 +108,7 @@ defmodule ExAws.Request.Url do
   def uri_encode(url), do: URI.encode(url, &valid_path_char?/1)
 
   # Space character
-  defp valid_path_char?(?\ ), do: false
+  defp valid_path_char?(?\s), do: false
   defp valid_path_char?(?/), do: true
 
   defp valid_path_char?(c) do


### PR DESCRIPTION
Found on Elixir 1.13, the compiler warning about usage of `?\ `. Fix
by using `?\s` instead.