### PR TITLE
adding me to "aws" partition

### DIFF
--- a/lib/ex_aws/config/defaults.ex
+++ b/lib/ex_aws/config/defaults.ex
@@ -82,7 +82,7 @@ defmodule ExAws.Config.Defaults do
   end
 
   @partitions [
-    {~r/^(us|eu|af|ap|sa|ca)\-\w+\-\d+$/, "aws"},
+    {~r/^(us|eu|af|ap|sa|ca|me)\-\w+\-\d+$/, "aws"},
     {~r/^cn\-\w+\-\d+$/, "aws-cn"},
     {~r/^us\-gov\-\w+\-\d+$/, "aws-us-gov"}
   ]


### PR DESCRIPTION
As part of PR https://github.com/ex-aws/ex_aws/pull/845 we added the support for endpoints in me-south-1.
But it does not work unless the me-south-1 region is added to the default config to reference to the AWS partition.

So new region needs to be first tied to a partition by making the changing in the below file and then the endpoints.exs file is referenced by the code 

fixes #844 

@bernardd pls merge and give us a tag to reference. Thanks
