### PR TITLE
Add Athena Support in ca-central-1

### DIFF
--- a/priv/endpoints.exs
+++ b/priv/endpoints.exs
@@ -707,6 +707,7 @@
             "ap-northeast-1" => %{},
             "ap-southeast-1" => %{},
             "ap-southeast-2" => %{},
+            "ca-central-1" => %{},
             "eu-central-1" => %{},
             "eu-west-1" => %{},
             "eu-west-2" => %{},


### PR DESCRIPTION
Athena is now available in AWS in ca-central-1

https://aws.amazon.com/about-aws/whats-new/2019/03/athena_canada_central/