### PR TITLE
Add Location service to "aws" partition

### DIFF
--- a/lib/ex_aws/config/defaults.ex
+++ b/lib/ex_aws/config/defaults.ex
@@ -66,6 +66,11 @@ defmodule ExAws.Config.Defaults do
     |> Map.merge(defaults(:timestream))
   end
 
+  def defaults(service) when service in [:places, :maps, :geofencing, :tracking, :routes] do
+    %{service_override: :geo}
+    |> Map.merge(defaults(:geo))
+  end
+
   def defaults(_) do
     Map.merge(
       %{
@@ -109,6 +114,11 @@ defmodule ExAws.Config.Defaults do
   defp service_map(:iot_data), do: "data.iot"
   defp service_map(:ingest_timestream), do: "ingest.timestream"
   defp service_map(:query_timestream), do: "query.timestream"
+  defp service_map(:places), do: "places.geo"
+  defp service_map(:maps), do: "maps.geo"
+  defp service_map(:geofencing), do: "geofencing.geo"
+  defp service_map(:tracking), do: "tracking.geo"
+  defp service_map(:routes), do: "routes.geo"
 
   defp service_map(service) do
     service

--- a/priv/endpoints.exs
+++ b/priv/endpoints.exs
@@ -2153,6 +2153,71 @@
             "us-east-2" => %{},
             "us-west-2" => %{}
           }
+        },
+        "places.geo" => %{
+          "endpoints" => %{
+            "us-east-1" => %{},
+            "us-east-2" => %{},
+            "us-west-1" => %{},
+            "eu-north-1" => %{},
+            "eu-central-1" => %{},
+            "eu-west-1" => %{},
+            "ap-northeast-1" => %{},
+            "ap-southeast-1" => %{},
+            "ap-southeast-2" => %{}
+          }
+        },
+        "maps.geo" => %{
+          "endpoints" => %{
+            "us-east-1" => %{},
+            "us-east-2" => %{},
+            "us-west-1" => %{},
+            "eu-north-1" => %{},
+            "eu-central-1" => %{},
+            "eu-west-1" => %{},
+            "ap-northeast-1" => %{},
+            "ap-southeast-1" => %{},
+            "ap-southeast-2" => %{}
+          }
+        },
+        "geofencing.geo" => %{
+          "endpoints" => %{
+            "us-east-1" => %{},
+            "us-east-2" => %{},
+            "us-west-1" => %{},
+            "eu-north-1" => %{},
+            "eu-central-1" => %{},
+            "eu-west-1" => %{},
+            "ap-northeast-1" => %{},
+            "ap-southeast-1" => %{},
+            "ap-southeast-2" => %{}
+          }
+        },
+        "tracking.geo" => %{
+          "endpoints" => %{
+            "us-east-1" => %{},
+            "us-east-2" => %{},
+            "us-west-1" => %{},
+            "eu-north-1" => %{},
+            "eu-central-1" => %{},
+            "eu-west-1" => %{},
+            "ap-northeast-1" => %{},
+            "ap-southeast-1" => %{},
+            "ap-southeast-2" => %{}
+          }
+        },
+        "routes.geo" => %{
+          "endpoints" => %{
+            "us-east-1" => %{},
+            "us-east-2" => %{},
+            "us-west-1" => %{},
+            "eu-north-1" => %{},
+            "eu-central-1" => %{},
+            "eu-west-1" => %{},
+            "ap-northeast-1" => %{},
+            "ap-southeast-1" => %{},
+            "ap-southeast-2" => %{}
+          }
         }
       }
     },


### PR DESCRIPTION
Enables the usage of [AWS Location Service](https://docs.aws.amazon.com/location/latest/developerguide/what-is.html) for the relevant regions.

This includes the maps, places, geofencing, tracking, and routes services, for [nine supported regions](https://docs.aws.amazon.com/location/latest/developerguide/location-regions.html).