### PR TITLE
Add support for AWS SSO credentials

### DIFF
--- a/lib/ex_aws/auth.ex
+++ b/lib/ex_aws/auth.ex
@@ -10,6 +10,9 @@ defmodule ExAws.Auth do
   @unsignable_headers ["x-amzn-trace-id"]
   @unsignable_headers_multi_case ["x-amzn-trace-id", "X-Amzn-Trace-Id"]
 
+  def validate_config(%{disable_headers_signature: true} = config),
+    do: {:ok, config}
+
   def validate_config(config) do
     with :ok <- get_key(config, :secret_access_key),
          :ok <- get_key(config, :access_key_id) do
@@ -32,6 +35,9 @@ defmodule ExAws.Auth do
         {:error, "Required key: #{inspect(key)} must be a string, but instead is #{inspect(val)}"}
     end
   end
+
+  def headers(_http_method, _url, _service, %{disable_headers_signature: true}, headers, _body),
+    do: {:ok, headers}
 
   def headers(http_method, url, service, config, headers, body) do
     with {:ok, config} <- validate_config(config) do

--- a/lib/ex_aws/config.ex
+++ b/lib/ex_aws/config.ex
@@ -143,7 +143,10 @@ defmodule ExAws.Config do
   def awscli_auth_credentials(profile, credentials_ini_provider \\ ExAws.CredentialsIni.File) do
     case Application.get_env(:ex_aws, :awscli_credentials, nil) do
       nil ->
-        credentials_ini_provider.security_credentials(profile)
+        case credentials_ini_provider.security_credentials(profile) do
+          {:ok, creds} -> creds
+          {:error, err} -> raise "Recieved error while retrieving security credentials: #{err}"
+        end
 
       %{^profile => profile_credentials} ->
         profile_credentials

--- a/lib/ex_aws/config.ex
+++ b/lib/ex_aws/config.ex
@@ -52,7 +52,7 @@ defmodule ExAws.Config do
     overrides = Map.new(opts)
 
     build_base(service, overrides)
-    |> Map.take([:http_client, :http_opts])
+    |> Map.take([:http_client, :http_opts, :json_codec])
     |> retrieve_runtime_config
   end
 

--- a/lib/ex_aws/config.ex
+++ b/lib/ex_aws/config.ex
@@ -44,6 +44,17 @@ defmodule ExAws.Config do
     |> parse_host_for_region
   end
 
+  @doc """
+  Builds a minimal HTTP configuration.
+  """
+  def http_config(service, opts \\ []) do
+    overrides = Map.new(opts)
+
+    build_base(service, overrides)
+    |> Map.take([:http_client, :http_opts])
+    |> retrieve_runtime_config
+  end
+
   def build_base(service, overrides \\ %{}) do
     common_config = Application.get_all_env(:ex_aws) |> Map.new() |> Map.take(@common_config)
     service_config = Application.get_env(:ex_aws, service, []) |> Map.new()

--- a/lib/ex_aws/config.ex
+++ b/lib/ex_aws/config.ex
@@ -11,6 +11,7 @@ defmodule ExAws.Config do
 
   @common_config [
     :http_client,
+    :http_opts,
     :json_codec,
     :access_key_id,
     :secret_access_key,

--- a/lib/ex_aws/credentials_ini/file.ex
+++ b/lib/ex_aws/credentials_ini/file.ex
@@ -89,6 +89,7 @@ if Code.ensure_loaded?(ConfigParser) do
         body
         |> Jason.decode()
       else
+        {:ok, resp} -> {:error, resp}
         error -> error
       end
     end

--- a/lib/ex_aws/credentials_ini/file.ex
+++ b/lib/ex_aws/credentials_ini/file.ex
@@ -83,9 +83,7 @@ if Code.ensure_loaded?(ConfigParser) do
              {:request,
               config[:http_client].request(
                 :get,
-                "https://portal.sso.#{region}.amazonaws.com/federation/credentials?account_id=#{
-                  account_id
-                }&role_name=#{role_name}",
+                "https://portal.sso.#{region}.amazonaws.com/federation/credentials?account_id=#{account_id}&role_name=#{role_name}",
                 "",
                 [{"x-amz-sso_bearer_token", access_token}],
                 Map.get(config, :http_opts, [])

--- a/lib/ex_aws/credentials_ini/file.ex
+++ b/lib/ex_aws/credentials_ini/file.ex
@@ -63,13 +63,15 @@ if Code.ensure_loaded?(ConfigParser) do
     end
 
     defp check_sso_expiration(expires_at_str) do
-      with {:ok, expires_at, _} <- DateTime.from_iso8601(expires_at_str) do
-        case DateTime.compare(expires_at, DateTime.utc_now()) do
-          :gt -> :ok
-          _ -> {:error, "SSO access token is expired, refresh the token with `aws sso login`"}
-        end
+      with {_, {:ok, expires_at, _}} <- {:timestamp, DateTime.from_iso8601(expires_at_str)},
+           {_, :gt} <- {:expires, DateTime.compare(expires_at, DateTime.utc_now())} do
+        :ok
       else
-        {:error, err} -> {:error, "SSO cache file has invalid expiration format: #{err}"}
+        {:timestamp, {:error, err}} ->
+          {:error, "SSO cache file has invalid expiration format: #{err}"}
+
+        {:expires, _} ->
+          {:error, "SSO access token is expired, refresh the token with `aws sso login`"}
       end
     end
 

--- a/lib/ex_aws/credentials_ini/file.ex
+++ b/lib/ex_aws/credentials_ini/file.ex
@@ -36,12 +36,14 @@ if Code.ensure_loaded?(ConfigParser) do
     defp get_sso_role_credentials(sso_start_url, sso_account_id, sso_role_name) do
       with {_, {:ok, sso_cache_content}} <-
              {:read, File.read(get_sso_cache_file(sso_start_url))},
-           {_, {:ok, %{"expiresAt" => expires_at, "accessToken" => access_token, "region" => region}}} <-
+           {_,
+            {:ok, %{"expiresAt" => expires_at, "accessToken" => access_token, "region" => region}}} <-
              {:decode, Jason.decode(sso_cache_content)},
            {_, :ok} <-
              {:expiration, check_sso_expiration(expires_at)},
            {_, {:ok, sso_creds}} <-
-             {:sso_creds, request_sso_role_credentials(access_token, region, sso_account_id, sso_role_name)},
+             {:sso_creds,
+              request_sso_role_credentials(access_token, region, sso_account_id, sso_role_name)},
            {_, {:ok, reformatted_creds}} <-
              {:rename, rename_sso_credential_keys(sso_creds)} do
         {:ok, reformatted_creds}
@@ -82,15 +84,16 @@ if Code.ensure_loaded?(ConfigParser) do
          ) do
       with config <- ExAws.Config.http_config(:sso),
            {_, {:ok, %{status_code: 200, headers: _headers, body: body_raw}}} <-
-             {:request, config[:http_client].request(
-               :get,
-               "https://portal.sso.#{region}.amazonaws.com/federation/credentials?account_id=#{
-                 account_id
-               }&role_name=#{role_name}",
-               "",
-               [{"x-amz-sso_bearer_token", access_token}],
-               Map.get(config, :http_opts, [])
-             )},
+             {:request,
+              config[:http_client].request(
+                :get,
+                "https://portal.sso.#{region}.amazonaws.com/federation/credentials?account_id=#{
+                  account_id
+                }&role_name=#{role_name}",
+                "",
+                [{"x-amz-sso_bearer_token", access_token}],
+                Map.get(config, :http_opts, [])
+              )},
            {_, {:ok, body}} <- {:decode, Jason.decode(body_raw)} do
         {:ok, body}
       else

--- a/lib/ex_aws/credentials_ini/file.ex
+++ b/lib/ex_aws/credentials_ini/file.ex
@@ -2,16 +2,96 @@ if Code.ensure_loaded?(ConfigParser) do
   defmodule ExAws.CredentialsIni.File do
     @moduledoc false
 
+    import ExAws.Request.Hackney, only: [request: 4]
     # as per https://docs.aws.amazon.com/cli/latest/topic/config-vars.html
     @valid_config_keys ~w(
       aws_access_key_id aws_secret_access_key aws_session_token region
       role_arn source_profile credential_source external_id mfa_serial role_session_name credential_process
+      sso_start_url sso_region sso_account_id sso_role_name
     )
 
     def security_credentials(profile_name) do
       shared_credentials = profile_from_shared_credentials(profile_name)
       config_credentials = profile_from_config(profile_name)
+      merge_credentials(config_credentials, shared_credentials)
+    end
+
+    defp merge_credentials(
+           %{
+             sso_start_url: sso_start_url,
+             sso_account_id: sso_account_id,
+             sso_role_name: sso_role_name
+           } = config_credentials,
+           _shared_credentials
+         ) do
+      get_sso_role_credentials(sso_start_url, sso_account_id, sso_role_name)
+      |> Map.merge(config_credentials)
+    end
+
+    defp merge_credentials(config_credentials, shared_credentials) do
       Map.merge(config_credentials, shared_credentials)
+    end
+
+    defp get_sso_cache_file(sso_start_url) do
+      hash = :crypto.hash(:sha, sso_start_url) |> Base.encode16() |> String.downcase()
+
+      System.user_home()
+      |> Path.join(".aws/sso/cache/#{hash}.json")
+    end
+
+    defp get_sso_role_credentials(sso_start_url, sso_account_id, sso_role_name) do
+      sso_start_url
+      |> get_sso_cache_file()
+      |> File.read()
+      |> parse_sso_cache_file()
+      # this only assumes happy path, should log error and return %{} or raise issue
+      |> request_sso_role_credentials(sso_account_id, sso_role_name)
+      |> rename_sso_credential_keys()
+    end
+
+    defp parse_sso_cache_file({:ok, contents}) do
+      #TODO: We could check expiration here and raise `aws sso login` as @ymtszw mentioned
+      contents
+      |> Jason.decode!()
+      |> Map.take(["accessToken"])
+    end
+
+    defp parse_sso_cache_file(_), do: %{}
+
+    #TODO: Implement check that verifies if a user has aws_sso and source profile configured
+    # Saw this concern raised in saml2aws using aws go sdk and think it could be helpful
+
+    # TODO: the :ex_aws.request() abstraction that can choose hackney or what users set requires signing
+    # We can't sign yet, so this is written to hackney, but need to revisit alternatives
+    defp request_sso_role_credentials(%{"accessToken" => access_token}, account_id, role_name) do
+      with {:ok, %{status_code: 200, headers: _headers, body: body}} <-
+             request(
+               :get,
+               # TODO: Need to pull sso_region, defult region, and default to us-east-1
+               "https://portal.sso.us-east-1.amazonaws.com/federation/credentials?account_id=#{account_id}&role_name=#{role_name}",
+               "",
+               [{"x-amz-sso_bearer_token", access_token}]
+             ) do
+        body
+        |> Jason.decode!()
+        |> Kernel.get_in(["roleCredentials"])
+      else
+        error -> error
+      end
+    end
+
+    defp request_sso_role_credentials(_, _, _), do: %{}
+
+    defp rename_sso_credential_keys(role_credentials) do
+      # TODO: make this future proof and just convert all to snake case or be explicit?
+      Enum.into(role_credentials, %{}, fn {k, v} ->
+        case k do
+          "accessKeyId" -> {:access_key_id, v}
+          "expiration" -> {:expiration, v}
+          "secretAccessKey" -> {:secret_access_key, v}
+          "sessionToken" -> {:session_token, v}
+        end
+      end)
     end
 
     def parse_ini_file({:ok, contents}, :system) do

--- a/lib/ex_aws/credentials_ini/file.ex
+++ b/lib/ex_aws/credentials_ini/file.ex
@@ -20,14 +20,14 @@ if Code.ensure_loaded?(ConfigParser) do
            %{
              sso_start_url: sso_start_url,
              sso_account_id: sso_account_id,
-             sso_role_name: sso_role_name,
+             sso_role_name: sso_role_name
            } = config_credentials,
            _shared_credentials
          ) do
-           case get_sso_role_credentials(sso_start_url, sso_account_id, sso_role_name) do
-             {:ok, sso_creds} -> {:ok, Map.merge(sso_creds, config_credentials)}
-             {:error, _} = err -> err
-           end
+      case get_sso_role_credentials(sso_start_url, sso_account_id, sso_role_name) do
+        {:ok, sso_creds} -> {:ok, Map.merge(sso_creds, config_credentials)}
+        {:error, _} = err -> err
+      end
     end
 
     defp merge_credentials(config_credentials, shared_credentials) do
@@ -63,8 +63,7 @@ if Code.ensure_loaded?(ConfigParser) do
     end
 
     defp check_sso_expiration(expires_at_str) do
-      with {:ok, expires_at, _} <- DateTime.from_iso8601(expires_at_str)
-      do
+      with {:ok, expires_at, _} <- DateTime.from_iso8601(expires_at_str) do
         case DateTime.compare(expires_at, DateTime.utc_now()) do
           :gt -> :ok
           _ -> {:error, "SSO access token is expired, refresh the token with `aws sso login`"}
@@ -74,39 +73,53 @@ if Code.ensure_loaded?(ConfigParser) do
       end
     end
 
-    #TODO: Implement check that verifies if a user has aws_sso and source profile configured
+    # TODO: Implement check that verifies if a user has aws_sso and source profile configured
     # Saw this concern raised in saml2aws using aws go sdk and think it could be helpful
 
     # TODO: the :ex_aws.request() abstraction that can choose hackney or what users set requires signing
     # We can't sign yet, so this is written to hackney, but need to revisit alternatives
-   defp request_sso_role_credentials(%{"accessToken" => access_token, "region" => region}, account_id, role_name) do
-     with {_, {:ok, %{status_code: 200, headers: _headers, body: body_raw}}} <-
-       {:request, request(
-         :get,
-         "https://portal.sso.#{region}.amazonaws.com/federation/credentials?account_id=#{account_id}&role_name=#{role_name}",
-         "",
-         [{"x-amz-sso_bearer_token", access_token}]
-       )},
-          {_, {:ok, body}} <- {:decode, Jason.decode(body_raw)} do
-       {:ok, body}
-     else
-       {:request, {_, %{status_code: status_code} = resp}} -> 
-         {:error, "SSO role credentials request responded with #{status_code}"}
-       {:decode, err} ->
-         {:error, "Could not decode SSO role credentials response"}
-     end
-   end
+    defp request_sso_role_credentials(
+           %{"accessToken" => access_token, "region" => region},
+           account_id,
+           role_name
+         ) do
+      with {_, {:ok, %{status_code: 200, headers: _headers, body: body_raw}}} <-
+             {:request,
+              request(
+                :get,
+                "https://portal.sso.#{region}.amazonaws.com/federation/credentials?account_id=#{
+                  account_id
+                }&role_name=#{role_name}",
+                "",
+                [{"x-amz-sso_bearer_token", access_token}]
+              )},
+           {_, {:ok, body}} <- {:decode, Jason.decode(body_raw)} do
+        {:ok, body}
+      else
+        {:request, {_, %{status_code: status_code} = resp}} ->
+          {:error, "SSO role credentials request responded with #{status_code}"}
+
+        {:decode, err} ->
+          {:error, "Could not decode SSO role credentials response"}
+      end
+    end
 
     defp rename_sso_credential_keys(%{"roleCredentials" => role_credentials}) do
-      with {_, access_key} when not is_nil(access_key) <- {:accessKey, Map.get(role_credentials, "accessKeyId")},
-           {_, expiration} when not is_nil(expiration) <- {:expiration, Map.get(role_credentials, "expiration")},
-           {_, secret_access_key} when not is_nil(secret_access_key) <- {:secretAccess, Map.get(role_credentials, "secretAccessKey")},
-           {_, session_token} when not is_nil(session_token) <- {:sessionToken, Map.get(role_credentials, "sessionToken")} do
-        {:ok, %{access_key_id: access_key,
-          expiration: expiration,
-          secret_access_key: secret_access_key,
-          security_token: session_token,
-        }}
+      with {_, access_key} when not is_nil(access_key) <-
+             {:accessKey, Map.get(role_credentials, "accessKeyId")},
+           {_, expiration} when not is_nil(expiration) <-
+             {:expiration, Map.get(role_credentials, "expiration")},
+           {_, secret_access_key} when not is_nil(secret_access_key) <-
+             {:secretAccess, Map.get(role_credentials, "secretAccessKey")},
+           {_, session_token} when not is_nil(session_token) <-
+             {:sessionToken, Map.get(role_credentials, "sessionToken")} do
+        {:ok,
+         %{
+           access_key_id: access_key,
+           expiration: expiration,
+           secret_access_key: secret_access_key,
+           security_token: session_token
+         }}
       else
         {missing, _} -> {:error, "#{missing} is missing from SSO role credential response"}
       end

--- a/lib/ex_aws/credentials_ini/file.ex
+++ b/lib/ex_aws/credentials_ini/file.ex
@@ -10,27 +10,23 @@ if Code.ensure_loaded?(ConfigParser) do
     )
 
     def security_credentials(profile_name) do
-      shared_credentials = profile_from_shared_credentials(profile_name)
       config_credentials = profile_from_config(profile_name)
-      merge_credentials(config_credentials, shared_credentials)
-    end
+      shared_credentials = profile_from_shared_credentials(profile_name)
 
-    defp merge_credentials(
-           %{
-             sso_start_url: sso_start_url,
-             sso_account_id: sso_account_id,
-             sso_role_name: sso_role_name
-           } = config_credentials,
-           _shared_credentials
-         ) do
-      case get_sso_role_credentials(sso_start_url, sso_account_id, sso_role_name) do
-        {:ok, sso_creds} -> {:ok, Map.merge(sso_creds, config_credentials)}
-        {:error, _} = err -> err
+      case config_credentials do
+        %{
+          sso_start_url: sso_start_url,
+          sso_account_id: sso_account_id,
+          sso_role_name: sso_role_name
+        } ->
+          case get_sso_role_credentials(sso_start_url, sso_account_id, sso_role_name) do
+            {:ok, sso_creds} -> {:ok, Map.merge(sso_creds, shared_credentials)}
+            {:error, _} = err -> err
+          end
+
+        _ ->
+          {:ok, Map.merge(config_credentials, shared_credentials)}
       end
-    end
-
-    defp merge_credentials(config_credentials, shared_credentials) do
-      {:ok, Map.merge(config_credentials, shared_credentials)}
     end
 
     defp get_sso_role_credentials(sso_start_url, sso_account_id, sso_role_name) do

--- a/lib/ex_aws/credentials_ini/file.ex
+++ b/lib/ex_aws/credentials_ini/file.ex
@@ -20,12 +20,14 @@ if Code.ensure_loaded?(ConfigParser) do
            %{
              sso_start_url: sso_start_url,
              sso_account_id: sso_account_id,
-             sso_role_name: sso_role_name
+             sso_role_name: sso_role_name,
            } = config_credentials,
            _shared_credentials
          ) do
-      get_sso_role_credentials(sso_start_url, sso_account_id, sso_role_name)
-      |> Map.merge(config_credentials)
+           case get_sso_role_credentials(sso_start_url, sso_account_id, sso_role_name) do
+             {:ok, sso_creds} -> {:ok, Map.merge(sso_creds, config_credentials)}
+             {:error, _} = err -> err
+           end
     end
 
     defp merge_credentials(config_credentials, shared_credentials) do
@@ -40,65 +42,67 @@ if Code.ensure_loaded?(ConfigParser) do
     end
 
     defp get_sso_role_credentials(sso_start_url, sso_account_id, sso_role_name) do
-
-      IO.puts("~~~ Getting the sso role credentials")
-
       sso_start_url
       |> get_sso_cache_file()
       |> File.read()
-      |> parse_sso_cache_file()
-      # this only assumes happy path, should log error and return %{} or raise issue
+      |> parse_sso_cache_file
+      |> check_sso_expiration
       |> request_sso_role_credentials(sso_account_id, sso_role_name)
-      |> rename_sso_credential_keys()
+      |> rename_sso_credential_keys
     end
 
     defp parse_sso_cache_file({:ok, contents}) do
-      #TODO: We could check expiration here and raise `aws sso login` as @ymtszw mentioned
-
-      IO.puts("Here I am!!!")
-
       contents
-      |> Jason.decode!()
-      |> Map.take(["accessToken"])
-      |> IO.inspect
+      |> Jason.decode()
     end
 
-    defp parse_sso_cache_file(_), do: %{}
+    defp parse_sso_cache_file(err), do: err
+
+    defp check_sso_expiration({:ok, %{"expiresAt" => expires_at} = config}) do
+      case Time.from_iso8601(expires_at) <= Time.utc_now() do
+        true ->
+          {:ok, config}
+        false ->
+          {:error, "SSO access token is expired, refresh the token with `aws sso login`"}
+      end
+    end
+
+    defp check_sso_expiration(err), do: err
 
     #TODO: Implement check that verifies if a user has aws_sso and source profile configured
     # Saw this concern raised in saml2aws using aws go sdk and think it could be helpful
 
     # TODO: the :ex_aws.request() abstraction that can choose hackney or what users set requires signing
     # We can't sign yet, so this is written to hackney, but need to revisit alternatives
-    defp request_sso_role_credentials(%{"accessToken" => access_token}, account_id, role_name) do
+    defp request_sso_role_credentials({:ok, %{"accessToken" => access_token, "region" => region}}, account_id, role_name) do
       with {:ok, %{status_code: 200, headers: _headers, body: body}} <-
              request(
                :get,
-               # TODO: Need to pull sso_region, defult region, and default to us-east-1
-               "https://portal.sso.us-east-1.amazonaws.com/federation/credentials?account_id=#{account_id}&role_name=#{role_name}",
+               "https://portal.sso.#{region}.amazonaws.com/federation/credentials?account_id=#{account_id}&role_name=#{role_name}",
                "",
                [{"x-amz-sso_bearer_token", access_token}]
              ) do
+
         body
-        |> Jason.decode!()
-        |> Kernel.get_in(["roleCredentials"])
+        |> Jason.decode()
       else
         error -> error
       end
     end
 
-    defp request_sso_role_credentials(_, _, _), do: %{}
+    defp request_sso_role_credentials(err, _, _), do: err
 
-    defp rename_sso_credential_keys(role_credentials) do
-      # TODO: make this future proof and just convert all to snake case or be explicit?
-      Enum.reduce(role_credentials, %{}, fn 
+    defp rename_sso_credential_keys({:ok, %{"roleCredentials" => role_credentials}}) do
+      {:ok, Enum.reduce(role_credentials, %{}, fn
         {"accessKeyId", v}, acc -> Map.put(acc, :access_key_id, v)
         {"expiration", v}, acc -> Map.put(acc, :expiration, v)
         {"secretAccessKey", v}, acc -> Map.put(acc, :secret_access_key, v)
-        {"sessionToken", v}, acc -> Map.put(acc, :session_token, v)
-        _, acc -> acc
+        {"sessionToken", v}, acc -> Map.put(acc, :security_token, v)
       end)
+      }
     end
+
+    defp rename_sso_credential_keys(err), do: err
 
     def parse_ini_file({:ok, contents}, :system) do
       parse_ini_file({:ok, contents}, profile_name_from_env())

--- a/lib/ex_aws/credentials_ini/file.ex
+++ b/lib/ex_aws/credentials_ini/file.ex
@@ -2,7 +2,6 @@ if Code.ensure_loaded?(ConfigParser) do
   defmodule ExAws.CredentialsIni.File do
     @moduledoc false
 
-    import ExAws.Request, only: [request: 6]
     # as per https://docs.aws.amazon.com/cli/latest/topic/config-vars.html
     @valid_config_keys ~w(
       aws_access_key_id aws_secret_access_key aws_session_token region
@@ -80,25 +79,25 @@ if Code.ensure_loaded?(ConfigParser) do
            account_id,
            role_name
          ) do
-      with {:ok, %{status_code: 200, headers: _headers, body: body_raw}} <-
-             request(
+      with config <- ExAws.Config.http_config(:sso),
+           {:ok, %{status_code: 200, headers: _headers, body: body_raw}} <-
+             config[:http_client].request(
                :get,
-               "https://portal.sso.#{region}.amazonaws.com/federation/credentials?account_id=#{account_id}&role_name=#{role_name}",
+               "https://portal.sso.#{region}.amazonaws.com/federation/credentials?account_id=#{
+                 account_id
+               }&role_name=#{role_name}",
                "",
                [{"x-amz-sso_bearer_token", access_token}],
-               ExAws.Config.new(:sso, disable_headers_signature: true),
-               :sso
+               Map.get(config, :http_opts, [])
              ),
            {_, {:ok, body}} <- {:decode, Jason.decode(body_raw)} do
         {:ok, body}
       else
-        # TODO: Do we want to include resp
         {:request, {_, %{status_code: status_code} = resp}} ->
-          {:error, "SSO role credentials request responded with #{status_code}"}
+          {:error, "SSO role credentials request responded with #{status_code}: #{resp}"}
 
-        # TODO: Same for err here do we want to include it
         {:decode, err} ->
-          {:error, "Could not decode SSO role credentials response"}
+          {:error, "Could not decode SSO role credentials response: #{err}"}
       end
     end
 

--- a/lib/ex_aws/credentials_ini/file.ex
+++ b/lib/ex_aws/credentials_ini/file.ex
@@ -31,7 +31,28 @@ if Code.ensure_loaded?(ConfigParser) do
     end
 
     defp merge_credentials(config_credentials, shared_credentials) do
-      Map.merge(config_credentials, shared_credentials)
+      {:ok, Map.merge(config_credentials, shared_credentials)}
+    end
+
+    defp get_sso_role_credentials(sso_start_url, sso_account_id, sso_role_name) do
+      with {_, {:ok, content_raw}} <-
+             {:read, File.read(get_sso_cache_file(sso_start_url))},
+           {_, {:ok, %{"expiresAt" => expires_at} = content}} <-
+             {:decode, Jason.decode(content_raw)},
+           {_, :ok} <-
+             {:expiration, check_sso_expiration(expires_at)},
+           {_, {:ok, sso_creds}} <-
+             {:sso_creds, request_sso_role_credentials(content, sso_account_id, sso_role_name)},
+           {_, {:ok, reformatted_creds}} <-
+             {:rename, rename_sso_credential_keys(sso_creds)} do
+        {:ok, reformatted_creds}
+      else
+        {:read, error} -> {:error, "Could not read SSO cache file"}
+        {:decode, error} -> {:error, "SSO cache file contains invalid json"}
+        {:expiration, error} -> error
+        {:sso_creds, error} -> error
+        {:rename, error} -> error
+      end
     end
 
     defp get_sso_cache_file(sso_start_url) do
@@ -41,28 +62,11 @@ if Code.ensure_loaded?(ConfigParser) do
       |> Path.join(".aws/sso/cache/#{hash}.json")
     end
 
-    defp get_sso_role_credentials(sso_start_url, sso_account_id, sso_role_name) do
-      sso_start_url
-      |> get_sso_cache_file()
-      |> File.read()
-      |> parse_sso_cache_file
-      |> check_sso_expiration
-      |> request_sso_role_credentials(sso_account_id, sso_role_name)
-      |> rename_sso_credential_keys
-    end
-
-    defp parse_sso_cache_file({:ok, contents}) do
-      contents
-      |> Jason.decode()
-    end
-
-    defp parse_sso_cache_file(err), do: err
-
-    defp check_sso_expiration({:ok, %{"expiresAt" => expires_at_str} = config}) do
+    defp check_sso_expiration(expires_at_str) do
       with {:ok, expires_at, _} <- DateTime.from_iso8601(expires_at_str)
       do
         case DateTime.compare(expires_at, DateTime.utc_now()) do
-          :gt -> {:ok, config}
+          :gt -> :ok
           _ -> {:error, "SSO access token is expired, refresh the token with `aws sso login`"}
         end
       else
@@ -70,43 +74,43 @@ if Code.ensure_loaded?(ConfigParser) do
       end
     end
 
-    defp check_sso_expiration(err), do: err
-
     #TODO: Implement check that verifies if a user has aws_sso and source profile configured
     # Saw this concern raised in saml2aws using aws go sdk and think it could be helpful
 
     # TODO: the :ex_aws.request() abstraction that can choose hackney or what users set requires signing
     # We can't sign yet, so this is written to hackney, but need to revisit alternatives
-    defp request_sso_role_credentials({:ok, %{"accessToken" => access_token, "region" => region}}, account_id, role_name) do
-      with {:ok, %{status_code: 200, headers: _headers, body: body}} <-
-             request(
-               :get,
-               "https://portal.sso.#{region}.amazonaws.com/federation/credentials?account_id=#{account_id}&role_name=#{role_name}",
-               "",
-               [{"x-amz-sso_bearer_token", access_token}]
-             ) do
+   defp request_sso_role_credentials(%{"accessToken" => access_token, "region" => region}, account_id, role_name) do
+     with {_, {:ok, %{status_code: 200, headers: _headers, body: body_raw}}} <-
+       {:request, request(
+         :get,
+         "https://portal.sso.#{region}.amazonaws.com/federation/credentials?account_id=#{account_id}&role_name=#{role_name}",
+         "",
+         [{"x-amz-sso_bearer_token", access_token}]
+       )},
+          {_, {:ok, body}} <- {:decode, Jason.decode(body_raw)} do
+       {:ok, body}
+     else
+       {:request, {_, %{status_code: status_code} = resp}} -> 
+         {:error, "SSO role credentials request responded with #{status_code}"}
+       {:decode, err} ->
+         {:error, "Could not decode SSO role credentials response"}
+     end
+   end
 
-        body
-        |> Jason.decode()
+    defp rename_sso_credential_keys(%{"roleCredentials" => role_credentials}) do
+      with {_, access_key} when not is_nil(access_key) <- {:accessKey, Map.get(role_credentials, "accessKeyId")},
+           {_, expiration} when not is_nil(expiration) <- {:expiration, Map.get(role_credentials, "expiration")},
+           {_, secret_access_key} when not is_nil(secret_access_key) <- {:secretAccess, Map.get(role_credentials, "secretAccessKey")},
+           {_, session_token} when not is_nil(session_token) <- {:sessionToken, Map.get(role_credentials, "sessionToken")} do
+        {:ok, %{access_key_id: access_key,
+          expiration: expiration,
+          secret_access_key: secret_access_key,
+          security_token: session_token,
+        }}
       else
-        {:ok, resp} -> {:error, resp}
-        error -> error
+        {missing, _} -> {:error, "#{missing} is missing from SSO role credential response"}
       end
     end
-
-    defp request_sso_role_credentials(err, _, _), do: err
-
-    defp rename_sso_credential_keys({:ok, %{"roleCredentials" => role_credentials}}) do
-      {:ok, Enum.reduce(role_credentials, %{}, fn
-        {"accessKeyId", v}, acc -> Map.put(acc, :access_key_id, v)
-        {"expiration", v}, acc -> Map.put(acc, :expiration, v)
-        {"secretAccessKey", v}, acc -> Map.put(acc, :secret_access_key, v)
-        {"sessionToken", v}, acc -> Map.put(acc, :security_token, v)
-      end)
-      }
-    end
-
-    defp rename_sso_credential_keys(err), do: err
 
     def parse_ini_file({:ok, contents}, :system) do
       parse_ini_file({:ok, contents}, profile_name_from_env())

--- a/lib/ex_aws/credentials_ini/file.ex
+++ b/lib/ex_aws/credentials_ini/file.ex
@@ -47,8 +47,8 @@ if Code.ensure_loaded?(ConfigParser) do
              {:rename, rename_sso_credential_keys(sso_creds)} do
         {:ok, reformatted_creds}
       else
-        {:read, error} -> {:error, "Could not read SSO cache file"}
-        {:decode, error} -> {:error, "SSO cache file contains invalid json"}
+        {:read, {:error, error}} -> {:error, "Could not read SSO cache file: #{error}"}
+        {:decode, _} -> {:error, "SSO cache file contains invalid json"}
         {:expiration, error} -> error
         {:sso_creds, error} -> error
         {:rename, error} -> error
@@ -98,10 +98,10 @@ if Code.ensure_loaded?(ConfigParser) do
            {_, {:ok, body}} <- {:decode, Jason.decode(body_raw)} do
         {:ok, body}
       else
-        {:request, {_, %{status_code: status_code} = resp}} ->
+        {:request, {_, %{status_code: status_code}}} ->
           {:error, "SSO role credentials request responded with #{status_code}"}
 
-        {:decode, err} ->
+        {:decode, _} ->
           {:error, "Could not decode SSO role credentials response"}
       end
     end

--- a/lib/ex_aws/credentials_ini/file.ex
+++ b/lib/ex_aws/credentials_ini/file.ex
@@ -58,12 +58,15 @@ if Code.ensure_loaded?(ConfigParser) do
 
     defp parse_sso_cache_file(err), do: err
 
-    defp check_sso_expiration({:ok, %{"expiresAt" => expires_at} = config}) do
-      case Time.from_iso8601(expires_at) <= Time.utc_now() do
-        true ->
-          {:ok, config}
-        false ->
-          {:error, "SSO access token is expired, refresh the token with `aws sso login`"}
+    defp check_sso_expiration({:ok, %{"expiresAt" => expires_at_str} = config}) do
+      with {:ok, expires_at, _} <- DateTime.from_iso8601(expires_at_str)
+      do
+        case DateTime.compare(expires_at, DateTime.utc_now()) do
+          :gt -> {:ok, config}
+          _ -> {:error, "SSO access token is expired, refresh the token with `aws sso login`"}
+        end
+      else
+        {:error, _} -> {:error, "SSO cache file has invalid expiration format"}
       end
     end
 

--- a/lib/ex_aws/credentials_ini/file.ex
+++ b/lib/ex_aws/credentials_ini/file.ex
@@ -40,6 +40,9 @@ if Code.ensure_loaded?(ConfigParser) do
     end
 
     defp get_sso_role_credentials(sso_start_url, sso_account_id, sso_role_name) do
+
+      IO.puts("~~~ Getting the sso role credentials")
+
       sso_start_url
       |> get_sso_cache_file()
       |> File.read()
@@ -51,9 +54,13 @@ if Code.ensure_loaded?(ConfigParser) do
 
     defp parse_sso_cache_file({:ok, contents}) do
       #TODO: We could check expiration here and raise `aws sso login` as @ymtszw mentioned
+
+      IO.puts("Here I am!!!")
+
       contents
       |> Jason.decode!()
       |> Map.take(["accessToken"])
+      |> IO.inspect
     end
 
     defp parse_sso_cache_file(_), do: %{}
@@ -85,13 +92,13 @@ if Code.ensure_loaded?(ConfigParser) do
     defp rename_sso_credential_keys(role_credentials) do
       # TODO: make this future proof and just convert all to snake case or be explicit?
       Enum.reduce(role_credentials, %{}, fn 
-          {"accessKeyId", v}, acc -> Map.put(acc, :access_key_id, v)
-          {"expiration", v}, acc -> Map.put(acc, :expiration, v)
-          {"secretAccessKey", v}, acc -> Map.put(acc, :secret_access_key, v)
-          {"sessionToken", v}, acc -> Map.put(acc, :session_token, v)
-          _, acc -> acc
-        end
+        {"accessKeyId", v}, acc -> Map.put(acc, :access_key_id, v)
+        {"expiration", v}, acc -> Map.put(acc, :expiration, v)
+        {"secretAccessKey", v}, acc -> Map.put(acc, :secret_access_key, v)
+        {"sessionToken", v}, acc -> Map.put(acc, :session_token, v)
+        _, acc -> acc
       end)
+    end
 
     def parse_ini_file({:ok, contents}, :system) do
       parse_ini_file({:ok, contents}, profile_name_from_env())

--- a/lib/ex_aws/credentials_ini/file.ex
+++ b/lib/ex_aws/credentials_ini/file.ex
@@ -2,7 +2,7 @@ if Code.ensure_loaded?(ConfigParser) do
   defmodule ExAws.CredentialsIni.File do
     @moduledoc false
 
-    import ExAws.Request.Hackney, only: [request: 4]
+    import ExAws.Request, only: [request: 6]
     # as per https://docs.aws.amazon.com/cli/latest/topic/config-vars.html
     @valid_config_keys ~w(
       aws_access_key_id aws_secret_access_key aws_session_token region
@@ -75,33 +75,29 @@ if Code.ensure_loaded?(ConfigParser) do
       end
     end
 
-    # TODO: Implement check that verifies if a user has aws_sso and source profile configured
-    # Saw this concern raised in saml2aws using aws go sdk and think it could be helpful
-
-    # TODO: the :ex_aws.request() abstraction that can choose hackney or what users set requires signing
-    # We can't sign yet, so this is written to hackney, but need to revisit alternatives
     defp request_sso_role_credentials(
            %{"accessToken" => access_token, "region" => region},
            account_id,
            role_name
          ) do
-      with {_, {:ok, %{status_code: 200, headers: _headers, body: body_raw}}} <-
-             {:request,
-              request(
-                :get,
-                "https://portal.sso.#{region}.amazonaws.com/federation/credentials?account_id=#{
-                  account_id
-                }&role_name=#{role_name}",
-                "",
-                [{"x-amz-sso_bearer_token", access_token}]
-              )},
+      with {:ok, %{status_code: 200, headers: _headers, body: body_raw}} <-
+             request(
+               :get,
+               "https://portal.sso.#{region}.amazonaws.com/federation/credentials?account_id=#{account_id}&role_name=#{role_name}",
+               "",
+               [{"x-amz-sso_bearer_token", access_token}],
+               ExAws.Config.new(:sso, disable_headers_signature: true),
+               :sso
+             ),
            {_, {:ok, body}} <- {:decode, Jason.decode(body_raw)} do
         {:ok, body}
       else
-        {:request, {_, %{status_code: status_code}}} ->
+        # TODO: Do we want to include resp
+        {:request, {_, %{status_code: status_code} = resp}} ->
           {:error, "SSO role credentials request responded with #{status_code}"}
 
-        {:decode, _} ->
+        # TODO: Same for err here do we want to include it
+        {:decode, err} ->
           {:error, "Could not decode SSO role credentials response"}
       end
     end

--- a/lib/ex_aws/credentials_ini/file.ex
+++ b/lib/ex_aws/credentials_ini/file.ex
@@ -66,7 +66,7 @@ if Code.ensure_loaded?(ConfigParser) do
           _ -> {:error, "SSO access token is expired, refresh the token with `aws sso login`"}
         end
       else
-        {:error, _} -> {:error, "SSO cache file has invalid expiration format"}
+        {:error, err} -> {:error, "SSO cache file has invalid expiration format: #{err}"}
       end
     end
 

--- a/lib/ex_aws/credentials_ini/file.ex
+++ b/lib/ex_aws/credentials_ini/file.ex
@@ -84,15 +84,14 @@ if Code.ensure_loaded?(ConfigParser) do
 
     defp rename_sso_credential_keys(role_credentials) do
       # TODO: make this future proof and just convert all to snake case or be explicit?
-      Enum.into(role_credentials, %{}, fn {k, v} ->
-        case k do
-          "accessKeyId" -> {:access_key_id, v}
-          "expiration" -> {:expiration, v}
-          "secretAccessKey" -> {:secret_access_key, v}
-          "sessionToken" -> {:session_token, v}
+      Enum.reduce(role_credentials, %{}, fn 
+          {"accessKeyId", v}, acc -> Map.put(acc, :access_key_id, v)
+          {"expiration", v}, acc -> Map.put(acc, :expiration, v)
+          {"secretAccessKey", v}, acc -> Map.put(acc, :secret_access_key, v)
+          {"sessionToken", v}, acc -> Map.put(acc, :session_token, v)
+          _, acc -> acc
         end
       end)
-    end
 
     def parse_ini_file({:ok, contents}, :system) do
       parse_ini_file({:ok, contents}, profile_name_from_env())

--- a/priv/endpoints.exs
+++ b/priv/endpoints.exs
@@ -2219,6 +2219,28 @@
             "ap-southeast-2" => %{}
           }
         }
+        # TODO: Double check these regions and add govcloud
+        "sso" => %{
+          "endpoints" => %{
+            "ap-northeast-1" => %{},
+            "ap-northeast-2" => %{},
+            "ap-east-1" => %{},
+            "ap-south-1" => %{},
+            "ap-southeast-1" => %{},
+            "ap-southeast-2" => %{},
+            "ca-central-1" => %{},
+            "eu-central-1" => %{},
+            "eu-west-1" => %{},
+            "eu-west-2" => %{},
+            "eu-west-3" => %{},
+            "eu-north-1" => %{},
+            "sa-east-1" => %{},
+            "us-east-1" => %{},
+            "us-east-2" => %{},
+            "us-west-1" => %{},
+            "us-west-2" => %{}
+          }
+        }
       }
     },
     %{

--- a/priv/endpoints.exs
+++ b/priv/endpoints.exs
@@ -2552,6 +2552,7 @@
         "sagemaker" => %{"endpoints" => %{"us-gov-west-1" => %{}}},
         "sso" => %{
           "endpoints" => %{
+            "us-gov-east-1" => %{},
             "us-gov-west-1" => %{}
           }
         }

--- a/priv/endpoints.exs
+++ b/priv/endpoints.exs
@@ -2549,7 +2549,12 @@
         "directconnect" => %{"endpoints" => %{"us-gov-east-1" => %{}, "us-gov-west-1" => %{}}},
         "cloudformation" => %{"endpoints" => %{"us-gov-east-1" => %{}, "us-gov-west-1" => %{}}},
         "swf" => %{"endpoints" => %{"us-gov-east-1" => %{}, "us-gov-west-1" => %{}}},
-        "sagemaker" => %{"endpoints" => %{"us-gov-west-1" => %{}}}
+        "sagemaker" => %{"endpoints" => %{"us-gov-west-1" => %{}}},
+        "sso" => %{
+          "endpoints" => %{
+            "us-gov-west-1" => %{}
+          }
+        }
       }
     }
   ],

--- a/priv/endpoints.exs
+++ b/priv/endpoints.exs
@@ -2218,8 +2218,7 @@
             "ap-southeast-1" => %{},
             "ap-southeast-2" => %{}
           }
-        }
-        # TODO: Double check these regions and add govcloud
+        },
         "sso" => %{
           "endpoints" => %{
             "ap-northeast-1" => %{},

--- a/test/ex_aws/config_test.exs
+++ b/test/ex_aws/config_test.exs
@@ -42,7 +42,7 @@ defmodule ExAws.ConfigTest do
     profile = "default"
 
     Mox.expect(ExAws.Credentials.InitMock, :security_credentials, 1, fn ^profile ->
-      %{region: "eu-west-1"}
+      {:ok, %{region: "eu-west-1"}}
     end)
 
     config = ExAws.Config.awscli_auth_credentials(profile, ExAws.Credentials.InitMock)

--- a/test/ex_aws/credentials_ini/file_test.exs
+++ b/test/ex_aws/credentials_ini/file_test.exs
@@ -18,6 +18,25 @@ defmodule ExAws.CredentialsIni.File.FileTest do
     assert credentials.security_token == "TESTTOKEN"
   end
 
+  test "config file is parsed with sso config" do
+    example_config = """
+    [default]
+    sso_start_url = https://start.us-gov-home.awsapps.com/directory/somecompany
+    sso_region = us-gov-west-1
+    sso_account_id = 123456789101
+    sso_role_name = SomeRole
+    region = us-gov-west-1
+    output = json
+    """
+
+    config = ExAws.CredentialsIni.File.parse_ini_file({:ok, example_config}, "default")
+
+    assert config.sso_start_url == "https://start.us-gov-home.awsapps.com/directory/somecompany"
+    assert config.sso_region == "us-gov-west-1"
+    assert config.sso_account_id == "123456789101"
+    assert config.sso_role_name == "SomeRole"
+  end
+
   test "{:system} in profile name gets dynamic profile name" do
     System.put_env("AWS_PROFILE", "custom-profile")
 


### PR DESCRIPTION
Work to resolve https://github.com/ex-aws/ex_aws/issues/843 based on the fork from @joeybaer. Huge thank you to both Joey and @patrickcsullivan for help and feedback on the PR!

Adds support in ExAws.CredentialsIni.File to pull the credentials expected throughout ex_aws from the temporary credentials provided by aws sso login stored in .aws/sso/cache/. This way users (like me) don't have to run a script prior to running elixir to generate the credentials and can instead just rely on the sso config like the aws cli does.

Sorry for a bit of spam creating this, didn't anticipate it would show up in the issue itself whenever I added a link to the issue from a PR description