### PR TITLE
Update spec for `Config.new/2` function

### DIFF
--- a/lib/ex_aws/config.ex
+++ b/lib/ex_aws/config.ex
@@ -35,7 +35,7 @@ defmodule ExAws.Config do
     4. Finally, any configuration overrides are merged in
 
   """
-  @spec new(atom, keyword) :: %{}
+  @spec new(atom, keyword) :: map()
   def new(service, opts \\ []) do
     overrides = Map.new(opts)
 


### PR DESCRIPTION
This PR updates the return type in spec for [`Config.new/2`](https://github.com/ex-aws/ex_aws/blob/c8015be9d89d9da2775b829b86ee4c6496877978/lib/ex_aws/config.ex#L39). Currently, the spec says that the return is specifically an empty map `%{}`, whereas I believe it should be the overall type `map()`.

For posterity's sake, I discovered this error when I tried to call [`S3.presigned_post/4`](https://github.com/ex-aws/ex_aws_s3/blob/6b375da2a1912d16f80e88860cbc9c74989588a9/lib/ex_aws/s3.ex#L1285) like so:
```
ExAws.Config.new(:s3)
|> ExAws.S3.presigned_post("bucket", "key")
```

which threw the following Dialyzer warning:
```
The call 'Elixir.ExAws.S3':presigned_post
         (#{},
          <<...>>,
          <<...>>) will never return since it differs in the 1st argument from the success typing arguments: 
         (#{'json_codec' := atom(), _ => _},
          binary(),
          'nil' | binary())
```

By the way, I'm using this project with DigitalOcean spaces for my Elixir project, and it is awesome! Thanks so much for all of your work on it!