### PR TITLE
Convert IMDSv2 header value to string

### DIFF
--- a/lib/ex_aws/instance_meta_token_provider.ex
+++ b/lib/ex_aws/instance_meta_token_provider.ex
@@ -112,6 +112,6 @@ defmodule ExAws.InstanceMetaTokenProvider do
   end
 
   defp token_ttl_seconds_headers(_config) do
-    [{@metadata_token_ttl_header_name, @metadata_token_ttl_seconds}]
+    [{@metadata_token_ttl_header_name, Integer.to_string(@metadata_token_ttl_seconds)}]
   end
 end


### PR DESCRIPTION
`InstanceMetaTokenProvider.request_token/1` currently uses an integer header value (`@metadata_token_ttl_seconds`), which breaks the contract for the `request` callback on `ExAws.Request.HttpClient`.

Similar to ex-aws/ex_aws#710