### PR TITLE
Adjust AWS partition detection regex

### DIFF
--- a/lib/ex_aws/config/defaults.ex
+++ b/lib/ex_aws/config/defaults.ex
@@ -90,7 +90,7 @@ defmodule ExAws.Config.Defaults do
   end
 
   @partitions [
-    {~r/^(us|eu|af|ap|sa|ca|me)\-\w+\-\d+$/, "aws"},
+    {~r/^(us|eu|af|ap|sa|ca|me)\-\w+\-\d$/, "aws"},
     {~r/^cn\-\w+\-\d+$/, "aws-cn"},
     {~r/^us\-gov\-\w+\-\d+$/, "aws-us-gov"}
   ]


### PR DESCRIPTION
There aren't any known AWS regions that have more than a single digit in the number (as far as I know). This regex fixes compatibility with Backblaze B2's region names, which are of the form `us-west-000`.