### PR TITLE
Handling empty paths sent to AWS

### DIFF
--- a/lib/ex_aws/request/url.ex
+++ b/lib/ex_aws/request/url.ex
@@ -103,7 +103,7 @@ defmodule ExAws.Request.Url do
     path
   end
 
-  def get_path(url, _), do: URI.parse(url).path
+  def get_path(url, _), do: URI.parse(url).path || "/"
 
   def uri_encode(url), do: URI.encode(url, &valid_path_char?/1)
 

--- a/test/ex_aws/request/url_test.exs
+++ b/test/ex_aws/request/url_test.exs
@@ -90,6 +90,11 @@ defmodule ExAws.Request.UrlTest do
       url = "https://example.com/uploads/invalid path but+valid//for#i-am-anchor"
       assert Url.get_path(url) == "/uploads/invalid path but+valid//for"
     end
+
+    test "returns an empty path when there isn't one specified in the url" do
+      url = "https://example.com"
+      assert Url.get_path(url) == "/"
+    end
   end
 
   describe "sanitize" do


### PR DESCRIPTION
Sometimes a URL may not specify a path to AWS, which in turn can cause an issue while a signature is being created for that URL.

**Current Behaviour:**

The following flow is executed when populating the headers

headers -> auth_headers -> signature -> get_path 

In get_path's current implementation, if the path is empty, it will return a nil value (which causes a matching error further on)

For example:

<img width="638" alt="image" src="https://user-images.githubusercontent.com/8846378/168896713-78585a0c-b68b-4ff6-8996-7d3fb5c6f8fc.png">

**Expected Behaviour:**

This PR adds a small change that allows for empty paths to be sent and the signature still being created for the specified URL. Instead of returning a nil value, get_path would return "/" upon discovering an empty path


**Note**:

Following the contribution guide here https://github.com/ex-aws/ex_aws/blob/bdc758048042e5db86179c843fdbbd9cbd2bbd4e/CONTRIBUTING.md

I tested my changes locally, added a unit test and also ran the automated tests (with a local DynamoDB instance running). I also ran mix format and mix dialyzer before pushing my changes.





