### PR TITLE
Use default profile when AWS_PROFILE is undefined

### DIFF
--- a/lib/ex_aws/credentials_ini/file.ex
+++ b/lib/ex_aws/credentials_ini/file.ex
@@ -193,12 +193,8 @@ if Code.ensure_loaded?(ConfigParser) do
       |> profile_from_name()
     end
 
-    defp profile_from_name(profile_name) do
-      case profile_name do
-        "default" -> "default"
-        other -> "profile #{other}"
-      end
-    end
+    defp profile_from_name("default"), do: "default"
+    defp profile_from_name(other), do: "profile #{other}"
 
     defp profile_name_from_env() do
       System.get_env("AWS_PROFILE") || "default"

--- a/lib/ex_aws/credentials_ini/file.ex
+++ b/lib/ex_aws/credentials_ini/file.ex
@@ -180,17 +180,24 @@ if Code.ensure_loaded?(ConfigParser) do
     end
 
     defp profile_from_config(profile_name) do
-      section =
-        case profile_name do
-          :system -> "profile #{profile_name_from_env()}"
-          "default" -> "default"
-          other -> "profile #{other}"
-        end
+      section = profile_from_name(profile_name)
 
       System.user_home()
       |> Path.join(".aws/config")
       |> File.read()
       |> parse_ini_file(section)
+    end
+
+    defp profile_from_name(:system) do
+      profile_name_from_env()
+      |> profile_from_name()
+    end
+
+    defp profile_from_name(profile_name) do
+      case profile_name do
+        "default" -> "default"
+        other -> "profile #{other}"
+      end
     end
 
     defp profile_name_from_env() do


### PR DESCRIPTION
`profile_from_config` uses incorrect profile when `:system` is being used e.g. (`{:awscli, :system, timeout}`).

It'll use `profile default` instead of just `default` if the AWS_PROFILE env var is unset. This PR fixes it