### PR TITLE
Include service in telemetry events

### DIFF
--- a/lib/ex_aws.ex
+++ b/lib/ex_aws.ex
@@ -62,6 +62,7 @@ defmodule ExAws do
 
     * `:result` - the request result: `:ok` or `:error`
     * `:attempt` - the attempt number
+    * `:service` - the AWS service
     * `:options` - extra options given to the repo operation under
       `:telemetry_options`
 

--- a/lib/ex_aws/request.ex
+++ b/lib/ex_aws/request.ex
@@ -35,7 +35,7 @@ defmodule ExAws.Request do
         )
       end
 
-      case do_request(config, method, safe_url, req_body, full_headers, attempt) do
+      case do_request(config, method, safe_url, req_body, full_headers, attempt, service) do
         {:ok, %{status_code: status} = resp} when status in 200..299 or status == 304 ->
           {:ok, resp}
 
@@ -92,10 +92,10 @@ defmodule ExAws.Request do
     end
   end
 
-  defp do_request(config, method, safe_url, req_body, full_headers, attempt) do
+  defp do_request(config, method, safe_url, req_body, full_headers, attempt, service) do
     telemetry_event = Map.get(config, :telemetry_event, [:ex_aws, :request])
     telemetry_options = Map.get(config, :telemetry_options, [])
-    telemetry_metadata = %{options: telemetry_options, attempt: attempt}
+    telemetry_metadata = %{options: telemetry_options, attempt: attempt, service: service}
 
     :telemetry.span(telemetry_event, telemetry_metadata, fn ->
       result =

--- a/test/ex_aws/request_test.exs
+++ b/test/ex_aws/request_test.exs
@@ -52,13 +52,15 @@ defmodule ExAws.RequestTest do
     assert_receive {[:ex_aws, :request, :start], %{system_time: _},
                     %{
                       options: [],
-                      attempt: 1
+                      attempt: 1,
+                      service: :s3
                     }}
 
     assert_receive {[:ex_aws, :request, :stop], %{duration: _},
                     %{
                       options: [],
                       attempt: 1,
+                      service: :s3,
                       result: :error
                     }}
   end
@@ -94,13 +96,15 @@ defmodule ExAws.RequestTest do
     assert_receive {[:ex_aws, :request, :start], %{system_time: _},
                     %{
                       options: [],
-                      attempt: 1
+                      attempt: 1,
+                      service: :s3
                     }}
 
     assert_receive {[:ex_aws, :request, :stop], %{duration: _},
                     %{
                       options: [],
                       attempt: 1,
+                      service: :s3,
                       result: :ok
                     }}
   end


### PR DESCRIPTION
Exposes service in telemetry events so that it's easier to see which services are being used in our monitoring.

I'm also wondering if there's a way to expose the name of the API being used. eg `GetObject` or `PutObject` for S3.