### PR TITLE
add more supported endpoints for medialive

### DIFF
--- a/priv/endpoints.exs
+++ b/priv/endpoints.exs
@@ -1397,14 +1397,20 @@
         },
         "medialive" => %{
           "endpoints" => %{
+            "ap-south-1" => %{},
             "ap-northeast-1" => %{},
             "ap-northeast-2" => %{},
             "ap-southeast-1" => %{},
             "ap-southeast-2" => %{},
             "eu-central-1" => %{},
             "eu-west-1" => %{},
+            "eu-west-2" => %{},
+            "eu-west-3" => %{},
+            "eu-north-1" => %{},
             "us-east-1" => %{},
-            "us-west-2" => %{}
+            "us-east-2" => %{},
+            "us-west-2" => %{},
+            "sa-east-1" => %{}
           }
         },
         "discovery" => %{"endpoints" => %{"us-west-2" => %{}}},


### PR DESCRIPTION
We are using `us-east-2` to manage our medialive channels but `us-east-2` still not supported in ExAws. 
The specified region is supported according to the AWS documentation.

<img width="1047" alt="image" src="https://user-images.githubusercontent.com/85470739/174225207-548c15fc-3c65-41dd-8e02-b0119620046d.png">

I want to add all missing supported endpoints for medialive according to Amazons documentation:
https://docs.aws.amazon.com/general/latest/gr/medialive_region.html