### PR TITLE
Add ap-southeast-3 to s3 region

### DIFF
--- a/priv/endpoints.exs
+++ b/priv/endpoints.exs
@@ -1325,6 +1325,10 @@
               "hostname" => "s3.ap-southeast-2.amazonaws.com",
               "signatureVersions" => ["s3", "s3v4"]
             },
+            "ap-southeast-3" => %{
+              "hostname" => "s3.ap-southeast-3.amazonaws.com",
+              "signatureVersions" => ["s3", "s3v4"]
+            },
             "af-south-1" => %{
               "hostname" => "s3.af-south-1.amazonaws.com",
               "signatureVersions" => ["s3", "s3v4"]


### PR DESCRIPTION
I face this issue today:
```
s3 not supported in region ap-southeast-3 for partition aws
```

I propose the changes to add `ap-southeast-3`.