### PR TITLE
Add me-south-1 to sqs endpoints

### DIFF
--- a/priv/endpoints.exs
+++ b/priv/endpoints.exs
@@ -1513,6 +1513,7 @@
             "fips-us-east-2" => %{},
             "fips-us-west-1" => %{},
             "fips-us-west-2" => %{},
+            "me-south-1" => %{},
             "sa-east-1" => %{},
             "us-east-1" => %{"sslCommonName" => "queue.{dnsSuffix}"},
             "us-east-2" => %{},


### PR DESCRIPTION
Hello and sorry for the impromptu request

We were testing a service for a couple of days and as we are using `elasticmq` locally we didn't run into this. However, as we deployed to our development environment we ran into this:

```
** (RuntimeError) sqs not supported in region me-south-1 for partition aws
(ex_aws 2.3.3) lib/ex_aws/config/defaults.ex:175: ExAws.Config.Defaults.fetch_or/3
(ex_aws 2.3.3) lib/ex_aws/config/defaults.ex:158: ExAws.Config.Defaults.do_host/3
(ex_aws 2.3.3) lib/ex_aws/config/defaults.ex:89: ExAws.Config.Defaults.get/2
(ex_aws 2.3.3) lib/ex_aws/config.ex:70: ExAws.Config.build_base/2
(ex_aws 2.3.3) lib/ex_aws/config.ex:43: ExAws.Config.new/2
(ex_aws 2.3.3) lib/ex_aws.ex:73: ExAws.request/2
```

So, I'm proposing adding the `me-south-1` region to the sqs endpoints

### Environment

    Erlang 25.0.2
    Elixir 1.13.4 (compiled with Erlang/OTP 25), 
    ExAws version 2.3.3
    HTTP client version. IE for hackney do mix deps | grep hackney: hackney 1.18.1

### Current behavior

SQS queues on `me-south-1` region won't work

### Expected behavior

SQS queues on `me-south-1` region should work