### PR TITLE
Remove warnings in test environment

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 config :logger, :console,
   level: :debug,

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 config :ex_aws,
   debug_requests: true,

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,1 +1,1 @@
-use Mix.Config
+import Config

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 config :logger, level: :warn
 

--- a/test/ex_aws/instance_meta_test.exs
+++ b/test/ex_aws/instance_meta_test.exs
@@ -77,7 +77,7 @@ defmodule ExAws.InstanceMetaTest do
       |> expect(:request, fn :put, _url, _body, _headers, _opts ->
         {:ok, %{status_code: 200, body: "dummy-token"}}
       end)
-      |> expect(:request, fn :get, _url, _body, headers, opts ->
+      |> expect(:request, fn :get, _url, _body, headers, _opts ->
         assert Enum.member?(headers, {"x-aws-ec2-metadata-token", "dummy-token"})
         {:ok, %{status_code: 200, body: role_name}}
       end)
@@ -101,7 +101,7 @@ defmodule ExAws.InstanceMetaTest do
       |> expect(:request, fn :put, _url, _body, _headers, _opts ->
         {:ok, %{status_code: 200, body: "dummy-token"}}
       end)
-      |> expect(:request, fn :get, _url, _body, headers, opts ->
+      |> expect(:request, fn :get, _url, _body, headers, _opts ->
         assert Enum.member?(headers, {"x-aws-ec2-metadata-token", "dummy-token"})
         {:ok, %{status_code: 200, body: role_name}}
       end)


### PR DESCRIPTION
It removes the following warnings when running the tests:

```
warning: use Mix.Config is deprecated. Use the Config module instead
  config/config.exs:1

warning: use Mix.Config is deprecated. Use the Config module instead
  config/test.exs:1

warning: variable "opts" is unused (if the variable is not meant to be used, prefix it with an underscore)
  test/ex_aws/instance_meta_test.exs:80: ExAws.InstanceMetaTest."test IMDSv2 when initial metadata request fails with a 401, fallback to IMDSv2 flow"/1

warning: variable "opts" is unused (if the variable is not meant to be used, prefix it with an underscore)
  test/ex_aws/instance_meta_test.exs:104: ExAws.InstanceMetaTest."test IMDSv2 configuration to use IMDSv2 by default"/1
```