### PR TITLE
Force refresh of config auth

### DIFF
--- a/lib/ex_aws/config.ex
+++ b/lib/ex_aws/config.ex
@@ -111,7 +111,7 @@ defmodule ExAws.Config do
     refreshable = Enum.flat_map(config, fn {_k, v} -> List.wrap(v) end)
     |> Enum.reduce([], fn
       {:awscli, _, _}, acc -> [:awscli | acc]
-      :role_instance, acc -> [:role_instance | acc]
+      :instance_role, acc -> [:instance_role | acc]
       _, acc -> acc
     end)
     |> Enum.uniq()

--- a/lib/ex_aws/config.ex
+++ b/lib/ex_aws/config.ex
@@ -2,9 +2,18 @@ defmodule ExAws.Config do
   @moduledoc """
   Generates the configuration for a service.
 
-  It starts with the defaults for a given environment
-  and then merges in the common config from the ex_aws config root,
-  and then finally any config specified for the particular service.
+  It starts with the defaults for a given environment and then merges in the
+  common config from the ex_aws config root, and then finally any config
+  specified for the particular service.
+
+  ## Refreshable fields
+
+  Some fields are marked as refreshable. These fields will be fetched through
+  the auth cache even if they are passed in as overrides. This is so stale
+  credentials aren't used, for example, with long running streams.
+
+  You can opt out of this behavior by passing `refreshable: false` when building
+  a config with `new/2`.
   """
 
   # TODO: Add proper documentation?

--- a/lib/ex_aws/config.ex
+++ b/lib/ex_aws/config.ex
@@ -95,20 +95,22 @@ defmodule ExAws.Config do
 
     defaults = ExAws.Config.Defaults.get(service, region)
 
-    config = defaults
-    |> Map.merge(common_config)
-    |> Map.merge(service_config)
-    |> add_refreshable_metadata()
+    config =
+      defaults
+      |> Map.merge(common_config)
+      |> Map.merge(service_config)
+      |> add_refreshable_metadata()
 
     # (Maybe) do not allow overrides for refreshable config.
-    overrides = if refreshable = overrides[:refreshable] do
-      Enum.reduce(refreshable, overrides, fn
-        :awscli, overrides -> Map.drop(overrides, @awscli_config)
-        :instance_role, overrides -> Map.drop(overrides, @instance_role_config)
-      end)
-    else
-      overrides
-    end
+    overrides =
+      if refreshable = overrides[:refreshable] do
+        Enum.reduce(refreshable, overrides, fn
+          :awscli, overrides -> Map.drop(overrides, @awscli_config)
+          :instance_role, overrides -> Map.drop(overrides, @instance_role_config)
+        end)
+      else
+        overrides
+      end
 
     Map.merge(config, overrides)
   end
@@ -117,13 +119,14 @@ defmodule ExAws.Config do
   # which is "refreshable". This is useful for long running streams where the
   # creds can change while the stream is still running.
   defp add_refreshable_metadata(config) do
-    refreshable = Enum.flat_map(config, fn {_k, v} -> List.wrap(v) end)
-    |> Enum.reduce([], fn
-      {:awscli, _, _}, acc -> [:awscli | acc]
-      :instance_role, acc -> [:instance_role | acc]
-      _, acc -> acc
-    end)
-    |> Enum.uniq()
+    refreshable =
+      Enum.flat_map(config, fn {_k, v} -> List.wrap(v) end)
+      |> Enum.reduce([], fn
+        {:awscli, _, _}, acc -> [:awscli | acc]
+        :instance_role, acc -> [:instance_role | acc]
+        _, acc -> acc
+      end)
+      |> Enum.uniq()
 
     if refreshable != [] do
       Map.put(config, :refreshable, refreshable)


### PR DESCRIPTION
## Problem

When ExAws streams an operation, it calculates a config map once, then passes that config as "overrides" for each request during the stream. This means that auth creds are resolved _once_ and used for the entire duration of the stream. If you have a stream that takes longer than 6 hours on an EC2 instance, you'll eventually get "token expired" errors.

## Fix

This PR detects refreshable creds in a config map, and uses `ExAws.Config.AuthCache` to resolve the creds on every request, even if an exist config map is passed as overrides.

This fix is completely transparent to downstream stream builders.

Fixes #824

## Testing

I tested locally by printing to stdout, but I have no idea how to unit test it. I'm currently testing in production to see if it's ultimately effective.

## How it works

Currently two types of configuration values (`:instance_role` and `:awscli`) use `ExAws.Config.AuthCache`, and thus have refreshable content.

The config map is augmented with a new field `:refreshable` which can be `false` or a list of refreshable values. For example:
```elixir
iex> config = ExAws.Config.new(:s3)
%{
  ...
  refreshable: [:awscli],
  ...
}
```

Now on subsequent calls, passing that config in as overrides, `new/2` knows to remove certain fields from the overrides which needs to be refreshed.

```elixir
iex> ExAws.Config.new(:s3, config)
%{
  ...
  refreshable: [:awscli],
  access_key_id: ..., # Potentially different
  secret_access_key: ..., # Potentially different
  security_token: ..., # Potentially different
  ...
}
```

Because `config` has `refreshable: [:awscli]`, we know we can delete things like `:access_key_id`, `:secret_access_key`, and `:security_token` from the overrides and let them be recalculated.

You can opt out of this behavior with...
```elixir
iex> config = ExAws.Config.new(:s3, refreshable: false)
%{
  ...
  refreshable: false,
  ...
}
```

But I don't know why you would want to.