### PR TITLE
Add ca-central-1 region to cognito-idp service

### DIFF
--- a/priv/endpoints.exs
+++ b/priv/endpoints.exs
@@ -1210,6 +1210,7 @@
             "ap-south-1" => %{},
             "ap-southeast-1" => %{},
             "ap-southeast-2" => %{},
+            "ca-central-1" => %{},
             "eu-central-1" => %{},
             "eu-west-1" => %{},
             "eu-west-2" => %{},


### PR DESCRIPTION
This commit authenticates Amazon Cognito users requesting access from Canada(Central) region.