### PR TITLE
Adds missing region for Rekognition in priv/endpoints.exs

### DIFF
--- a/priv/endpoints.exs
+++ b/priv/endpoints.exs
@@ -1313,6 +1313,7 @@
             "ca-central-1" => %{},
             "eu-central-1" => %{},
             "eu-west-1" => %{},
+            "eu-west-2" => %{},
             "us-east-1" => %{},
             "us-east-2" => %{},
             "us-west-1" => %{},


### PR DESCRIPTION
Problem
---------
I came across with the following error when I had tried to run `AWS Rekognition` for an image stored in S3 in London region (eu-west-2):
<img width="823" alt="Screen Shot 2022-10-18 at 12 45 32" src="https://user-images.githubusercontent.com/5793927/196480379-6ed3bc62-869a-479a-8d2c-bea595e7789e.png">

Fix
---
This PR adds missing `eu-west-2` region for Rekognition in 'priv/endpoints.exs file.

All service endpoints availables can be read in [Amazon Rekognition endpoints and quotas](https://docs.aws.amazon.com/general/latest/gr/rekognition.html) page.