### PR TITLE
Increase AWS -related auth. compatibility

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -22,6 +22,10 @@ jobs:
         with:
           port: 8000
           cors: "*"
+      - name: LocalStack - Kinesis
+        run: |
+          docker run --detach --publish 4567:4566 localstack/localstack
+          until curl -s http://localhost:4567; do sleep 0.5; done
       - run: mix deps.get
       - run: mix compile
       - run: mix format --check-formatted

--- a/config/test.exs
+++ b/config/test.exs
@@ -35,3 +35,9 @@ config :ex_aws, :s3,
   scheme: "https://",
   host: "s3.amazonaws.com",
   region: "us-east-1"
+
+config :ex_aws, :kinesis,
+  scheme: "http://",
+  host: "localhost",
+  port: 4567,
+  region: "eu-west-1"

--- a/lib/ex_aws/auth.ex
+++ b/lib/ex_aws/auth.ex
@@ -138,10 +138,10 @@ defmodule ExAws.Auth do
     [
       "AWS4-HMAC-SHA256 Credential=",
       Credentials.generate_credential_v4(service, config, datetime),
-      ",",
+      ", ",
       "SignedHeaders=",
       signed_headers(headers),
-      ",",
+      ", ",
       "Signature=",
       signature
     ]

--- a/test/ex_aws/ex_aws_test.exs
+++ b/test/ex_aws/ex_aws_test.exs
@@ -124,4 +124,18 @@ defmodule ExAwsTest do
                       result: :error
                     }}
   end
+
+  test "kinesis signed request" do
+    op = %ExAws.Operation.JSON{
+      http_method: :post,
+      path: "/",
+      service: :kinesis,
+      headers: [
+        {"x-amz-target", "Kinesis_20131202.ListStreams"},
+        {"content-type", "application/x-amz-json-1.1"}
+      ]
+    }
+
+    assert {:ok, %{"HasMoreStreams" => false, "StreamNames" => []}} = ExAws.request(op)
+  end
 end


### PR DESCRIPTION
I'm using [`localstack`](https://github.com/localstack/localstack) to perform local tests on top of `ex_aws`.

I'm getting the following error 

```
"Authorization header requires \\Signature\\ parameter. Authorization header requires \\SignedHeaders\\ parameter.
```

as part of HTTP calls. I've run the request with `debug_requests: true` and found that the `Authorization` header does have those parameters, but... they're written like this

```
AWS4-HMAC-SHA256 Credential=<cred>,SignedHeaders=<sign_head>,Signature=<sign>
```

instead of

```
AWS4-HMAC-SHA256 Credential=<cred>, SignedHeaders=<sign_head>, Signature=<sign>
                                   ^ notice the extra space
```

This pull request adds the extra space, which is what's issued by the official AWS client, in any case.

I also add LocalStack to CI for future regression testing purposes (if CI isn't running - because this is my first contribution to the repo., you can check results here: https://github.com/paulo-ferraz-oliveira/ex_aws/actions/runs/3726712502/jobs/6320334886).