### PR TITLE
Add eu-west-2 to sagemaker endpoints

### DIFF
--- a/priv/endpoints.exs
+++ b/priv/endpoints.exs
@@ -697,6 +697,7 @@
           "endpoints" => %{
             "ap-northeast-1" => %{},
             "eu-west-1" => %{},
+            "eu-west-2" => %{},
             "us-east-1" => %{},
             "us-east-2" => %{},
             "us-west-2" => %{}


### PR DESCRIPTION
Added region `eu-west-2` to SageMaker endpoints so we can make use of [ex_aws_sagemaker_runtime](https://github.com/dideler/ex_aws_sagemaker_runtime) in this region.