### PR TITLE
Fix happy path-only http client doc

### DIFF
--- a/lib/ex_aws/request/http_client.ex
+++ b/lib/ex_aws/request/http_client.ex
@@ -18,8 +18,15 @@ defmodule ExAws.Request.HttpClient do
 
       defmodule ExAws.Request.HTTPotion do
         @behaviour ExAws.Request.HttpClient
-        def request(method, url, body, headers, http_opts) do
-          {:ok, HTTPotion.request(method, url, [body: body, headers: headers, ibrowse: [headers_as_is: true]])}
+        def request(method, url, body, headers, _http_opts) do
+          case HTTPotion.request(method, url,
+                body: body,
+                headers: headers,
+                ibrowse: [headers_as_is: true]
+              ) do
+            %HTTPotion.Response{} = response -> {:ok, response}
+            %HTTPotion.ErrorResponse{} = error -> {:error, %{reason: error}}
+          end
         end
       end
 


### PR DESCRIPTION
Thank you for all your hard work! Below is a slight docs improvement.

A current example of custom `ExAws.Request.HttpClient` behaviour implementation always packs the response in `{:ok, result}` tuple, which only works for happy path and breaks if the underlying client returns an error.

The proposed example correctly packs errors in the error tuple that ExAws.Request.request_and_retry/7 function is expecting.

