### PR TITLE
Support long-running streams with task role authentication

### DIFF
--- a/lib/ex_aws.ex
+++ b/lib/ex_aws.ex
@@ -106,7 +106,7 @@ defmodule ExAws do
   @impl ExAws.Behaviour
   @spec stream!(ExAws.Operation.t(), keyword) :: Enumerable.t()
   def stream!(op, config_overrides \\ []) do
-    ExAws.Operation.stream!(op, ExAws.Config.new(op.service, config_overrides))
+    ExAws.Operation.stream!(op, config_overrides)
   end
 
   @doc false


### PR DESCRIPTION
# Context

`ExAws.stream!` calls `ExAws.Config.new` with the provided `config_overrides`, before calling the relevant `ExAws.Operation` implementation. This resolved config is subsequently provided as `config_overrides` to all calls the `ExAws.Operation` implementation will make to `ExAws.request`, leaving no possibility for task role authentication when the config is resolved again in those calls.

This means that credentials will only be fetched once for a stream. And since credentials are only valid for up to six hours, long-running streams are likely or guaranteed to fail. This has also been reported in #824.

# Implementation

This removes the call to `ExAws.Config.new` in `ExAws.stream!`, letting the `ExAws.Operation` implementation take the actual overrides and resolve the config later. We have tested this successfully with the `ExAws.S3.Download` operation, but I'm not sure about other operations. Are there implementations of `ExAws.Operation.stream!` that expects a resolved config?

If there are, we could also resolve everything but the credentials in `ExAws.stream!`. Or resolve the config for all operations but `ExAws.S3.Download` and other operations we know are safe. But that's of course not as nice.

#904 also fixes this problem. But if possible, I think it would be better to fix the problem without configuration updates, since this is the expected behavior (I think).