### PR TITLE
Add eu-west-2 to firehose endpoints

### DIFF
--- a/priv/endpoints.exs
+++ b/priv/endpoints.exs
@@ -55,6 +55,7 @@
             "ca-central-1" => %{},
             "eu-central-1" => %{},
             "eu-west-1" => %{},
+            "eu-west-2" => %{},
             "eu-west-3" => %{},
             "us-east-1" => %{},
             "us-east-2" => %{},


### PR DESCRIPTION
Firehose's eu-west-2 endpoint is not listed as active in the endpoints config. Therefore you get the error:

```
** (RuntimeError) firehose not supported in region eu-west-2 for partition aws
```

Checking the endpoints available for firehose, `eu-west-2` is listed as an active endpoint:
https://docs.aws.amazon.com/general/latest/gr/fh.html