### PR TITLE
Add operation name to telemetry metadata closes #930

### DIFF
--- a/lib/ex_aws/request.ex
+++ b/lib/ex_aws/request.ex
@@ -95,7 +95,7 @@ defmodule ExAws.Request do
   defp do_request(config, method, safe_url, req_body, full_headers, attempt, service) do
     telemetry_event = Map.get(config, :telemetry_event, [:ex_aws, :request])
     telemetry_options = Map.get(config, :telemetry_options, [])
-    telemetry_metadata = %{options: telemetry_options, attempt: attempt, service: service}
+    telemetry_metadata = %{options: telemetry_options, attempt: attempt, service: service, operation: extract_operation(full_headers)}
 
     :telemetry.span(telemetry_event, telemetry_metadata, fn ->
       result =
@@ -117,6 +117,11 @@ defmodule ExAws.Request do
       {result, telemetry_metadata}
     end)
   end
+
+  defp extract_operation(headers), do: Enum.find_value(headers, &match_operation/1)
+
+  defp match_operation({"x-amz-target", value}), do: value
+  defp match_operation({_key, _value}), do: nil
 
   def client_error(%{status_code: status, body: body} = error, json_codec) do
     case json_codec.decode(body) do

--- a/lib/ex_aws/request.ex
+++ b/lib/ex_aws/request.ex
@@ -95,7 +95,13 @@ defmodule ExAws.Request do
   defp do_request(config, method, safe_url, req_body, full_headers, attempt, service) do
     telemetry_event = Map.get(config, :telemetry_event, [:ex_aws, :request])
     telemetry_options = Map.get(config, :telemetry_options, [])
-    telemetry_metadata = %{options: telemetry_options, attempt: attempt, service: service, operation: extract_operation(full_headers)}
+
+    telemetry_metadata = %{
+      options: telemetry_options,
+      attempt: attempt,
+      service: service,
+      operation: extract_operation(full_headers)
+    }
 
     :telemetry.span(telemetry_event, telemetry_metadata, fn ->
       result =


### PR DESCRIPTION
Improve telemetry events with name of the `operation`, the new events will look like:

```elixir
%{
  attempt: 1,
  options: [],
  result: :ok,
  service: :secretsmanager,
  operation: "secretsmanager.GetSecretValue"
  telemetry_span_context: #Reference<0.3450093779.1724645383.45512>
}
```