### PR TITLE
Add request and response to telemetry

### DIFF
--- a/lib/ex_aws/request.ex
+++ b/lib/ex_aws/request.ex
@@ -118,6 +118,7 @@ defmodule ExAws.Request do
         case result do
           {:ok, %{status_code: status} = resp} when status in 200..299 or status == 304 ->
             %{result: :ok, response_body: Map.get(resp, :body)}
+
           error ->
             %{result: :error, error: extract_error(error)}
         end

--- a/lib/ex_aws/request.ex
+++ b/lib/ex_aws/request.ex
@@ -100,6 +100,7 @@ defmodule ExAws.Request do
       options: telemetry_options,
       attempt: attempt,
       service: service,
+      request_body: req_body,
       operation: extract_operation(full_headers)
     }
 
@@ -113,13 +114,15 @@ defmodule ExAws.Request do
           Map.get(config, :http_opts, [])
         )
 
-      telemetry_result =
+      stop_metadata =
         case result do
-          {:ok, %{status_code: status}} when status in 200..299 or status == 304 -> :ok
-          _ -> :error
+          {:ok, %{status_code: status} = resp} when status in 200..299 or status == 304 ->
+            %{result: :ok, response_body: Map.get(resp, :body)}
+          error ->
+            %{result: :error, error: extract_error(error)}
         end
 
-      telemetry_metadata = Map.put(telemetry_metadata, :result, telemetry_result)
+      telemetry_metadata = Map.merge(telemetry_metadata, stop_metadata)
       {result, telemetry_metadata}
     end)
   end
@@ -128,6 +131,11 @@ defmodule ExAws.Request do
 
   defp match_operation({"x-amz-target", value}), do: value
   defp match_operation({_key, _value}), do: nil
+
+  defp extract_error({:ok, %{body: body}}), do: body
+  defp extract_error({:ok, response}), do: response
+  defp extract_error({:error, error}), do: error
+  defp extract_error(error), do: error
 
   def client_error(%{status_code: status, body: body} = error, json_codec) do
     case json_codec.decode(body) do

--- a/test/ex_aws/ex_aws_test.exs
+++ b/test/ex_aws/ex_aws_test.exs
@@ -37,14 +37,17 @@ defmodule ExAwsTest do
     assert_receive {[:ex_aws, :request, :start], %{system_time: _},
                     %{
                       attempt: 1,
-                      options: []
+                      options: [],
+                      request_body: "{}"
                     }}
 
     assert_receive {[:ex_aws, :request, :stop], %{duration: _},
                     %{
                       options: [],
                       attempt: 1,
-                      result: :ok
+                      request_body: "{}",
+                      result: :ok,
+                      response_body: "{\"TableNames\":[]}"
                     }}
   end
 
@@ -148,14 +151,17 @@ defmodule ExAwsTest do
     assert_receive {[:ex_aws, :request, :start], %{system_time: _},
                     %{
                       options: [],
-                      attempt: 1
+                      attempt: 1,
+                      request_body: "{}"
                     }}
 
     assert_receive {[:ex_aws, :request, :stop], %{duration: _},
                     %{
                       options: [],
                       attempt: 1,
-                      result: :error
+                      request_body: "{}",
+                      result: :error,
+                      error: ~s({"__type":"com.amazon.coral.validate#ValidationException","Message":"Invalid table/index name.  Table/index names must be between 3 and 255 characters long, and may contain only the characters a-z, A-Z, 0-9, '_', '-', and '.'"})
                     }}
   end
 end

--- a/test/ex_aws/ex_aws_test.exs
+++ b/test/ex_aws/ex_aws_test.exs
@@ -161,7 +161,8 @@ defmodule ExAwsTest do
                       attempt: 1,
                       request_body: "{}",
                       result: :error,
-                      error: ~s({"__type":"com.amazon.coral.validate#ValidationException","Message":"Invalid table/index name.  Table/index names must be between 3 and 255 characters long, and may contain only the characters a-z, A-Z, 0-9, '_', '-', and '.'"})
+                      error:
+                        ~s({"__type":"com.amazon.coral.validate#ValidationException","Message":"Invalid table/index name.  Table/index names must be between 3 and 255 characters long, and may contain only the characters a-z, A-Z, 0-9, '_', '-', and '.'"})
                     }}
   end
 end


### PR DESCRIPTION
I'm working on a library to adapt ExAws's telemetry into [OpenTelemetry](https://opentelemetry.io/) data. OpenTelemetry actually has a set of recommendations for which data to include here: [Semantic conventions for AWS SDK](https://opentelemetry.io/docs/reference/specification/trace/semantic_conventions/instrumentation/aws-sdk/). If ExAws can include the request and response bodies in its telemetry, the adapter library can include all the data that OpenTelemetry requests.

The PR for that adapter library is here: <https://github.com/open-telemetry/opentelemetry-erlang-contrib/pull/152>.