### PR TITLE
Add support for IVS endpoints

### DIFF
--- a/priv/endpoints.exs
+++ b/priv/endpoints.exs
@@ -792,6 +792,29 @@
             "us-west-2" => %{}
           }
         },
+        "ivs" => %{
+          "defaults" => %{"protocols" => ["http", "https"]},
+          "endpoints" => %{
+            "ap-northeast-1" => %{},
+            "ap-northeast-2" => %{},
+            "ap-east-1" => %{},
+            "ap-south-1" => %{},
+            "ap-southeast-1" => %{},
+            "ap-southeast-2" => %{},
+            "ca-central-1" => %{},
+            "eu-central-1" => %{},
+            "eu-west-1" => %{},
+            "eu-west-2" => %{},
+            "eu-west-3" => %{},
+            "eu-north-1" => %{},
+            "eu-south-1" => %{},
+            "sa-east-1" => %{},
+            "us-east-1" => %{},
+            "us-east-2" => %{},
+            "us-west-1" => %{},
+            "us-west-2" => %{}
+          }
+        },
         "ec2" => %{
           "defaults" => %{"protocols" => ["http", "https"]},
           "endpoints" => %{


### PR DESCRIPTION
Just supporting [IVS as authorized](https://docs.aws.amazon.com/ivs/latest/APIReference/API_CreateChannel.html) AWS service. 