### PR TITLE
Feature/enable fsx

### DIFF
--- a/priv/endpoints.exs
+++ b/priv/endpoints.exs
@@ -2461,7 +2461,7 @@
               "hostname" => "fsx-fips.us-gov-west-1.amazonaws.com"
             }
           }
-          },
+        },
         "config" => %{"endpoints" => %{"us-gov-east-1" => %{}, "us-gov-west-1" => %{}}},
         "iam" => %{
           "endpoints" => %{

--- a/priv/endpoints.exs
+++ b/priv/endpoints.exs
@@ -1815,6 +1815,38 @@
             "us-west-2" => %{}
           }
         },
+        "fsx" => %{
+          "endpoints" => %{
+            "us-east-2" => %{},
+            "us-east-1" => %{},
+            "us-west-1" => %{},
+            "us-west-2" => %{},
+            "af-south-1" => %{},
+            "ap-east-1" => %{},
+            "ap-south-2" => %{},
+            "ap-southeast-3" => %{},
+            "ap-south-1" => %{},
+            "ap-northeast-3" => %{},
+            "ap-northeast-2" => %{},
+            "ap-southeast-1" => %{},
+            "ap-southeast-2" => %{},
+            "ap-northeast-1" => %{},
+            "ca-central-1" => %{},
+            "eu-central-1" => %{},
+            "eu-west-1" => %{},
+            "eu-west-2" => %{},
+            "eu-south-1" => %{},
+            "eu-west-3" => %{},
+            "eu-south-2" => %{},
+            "eu-north-1" => %{},
+            "eu-central-2" => %{},
+            "me-south-1" => %{},
+            "me-central-1" => %{},
+            "sa-east-1" => %{},
+            "us-gov-east-1" => %{},
+            "us-gov-west-1" => %{}
+          }
+        },
         "elasticfilesystem" => %{
           "endpoints" => %{
             "ap-northeast-2" => %{},
@@ -2418,6 +2450,18 @@
       },
       "services" => %{
         "elasticache" => %{"endpoints" => %{"us-gov-east-1" => %{}, "us-gov-west-1" => %{}}},
+        "fsx" => %{
+          "endpoints" => %{
+            "us-gov-east-1" => %{
+              "credentialScope" => %{"region" => "us-gov-east-1"},
+              "hostname" => "fsx-fips.us-gov-east-1.amazonaws.com"
+            },
+            "us-gov-west-1" => %{
+              "credentialScope" => %{"region" => "us-gov-west-1"},
+              "hostname" => "fsx-fips.us-gov-west-1.amazonaws.com"
+            }
+          }
+          },
         "config" => %{"endpoints" => %{"us-gov-east-1" => %{}, "us-gov-west-1" => %{}}},
         "iam" => %{
           "endpoints" => %{


### PR DESCRIPTION
* Run `mix format` using a recent version of Elixir :heavy_check_mark: 
* Run `mix dialyzer` to make sure the typing is correct :heavy_check_mark: 
* Run `mix test` to ensure no tests have broken (also please make sure you've added tests for your particular change, where appropriate). N/A


This enables the FSx endpoints, including FIPs endpoints for federal.

The endpoint list comes from: 

[FSx docs](https://docs.aws.amazon.com/general/latest/gr/fsxn.html)

Tested the configuration change with:

```
%ExAws.Operation.JSON{
      http_method: :POST,
      headers: [
        {"x-amz-target", "AWSSimbaAPIService_v20180301.DescribeFileSystems"},
        {"content-type", "application/x-amz-json-1.1"}
      ],
      path: "/",
      params: %{},
      data: %{},
      service: :fsx
    }
```

based upon this [spec](https://github.com/aws/aws-sdk-go/blob/main/models/apis/fsx/2018-03-01/api-2.json)