### PR TITLE
Add support for EventBridge Scheduler endpoints

### DIFF
--- a/priv/endpoints.exs
+++ b/priv/endpoints.exs
@@ -375,6 +375,27 @@
             "us-west-2" => %{}
           }
         },
+        "scheduler" => %{
+          "endpoints" => %{
+            "ap-northeast-1" => %{},
+            "ap-northeast-2" => %{},
+            "ap-east-1" => %{},
+            "ap-south-1" => %{},
+            "ap-southeast-1" => %{},
+            "ap-southeast-2" => %{},
+            "ca-central-1" => %{},
+            "eu-central-1" => %{},
+            "eu-west-1" => %{},
+            "eu-west-2" => %{},
+            "eu-west-3" => %{},
+            "eu-north-1" => %{},
+            "sa-east-1" => %{},
+            "us-east-1" => %{},
+            "us-east-2" => %{},
+            "us-west-1" => %{},
+            "us-west-2" => %{}
+          }
+        },
         "guardduty" => %{
           "defaults" => %{"protocols" => ["https"]},
           "endpoints" => %{


### PR DESCRIPTION
Adding support to [EventBridge Scheduler](https://docs.aws.amazon.com/scheduler/latest/APIReference/Welcome.html) as an AWS service.