### PR TITLE
Add `me-south-1` to SNS endpoints

### DIFF
--- a/priv/endpoints.exs
+++ b/priv/endpoints.exs
@@ -434,6 +434,7 @@
             "eu-west-2" => %{},
             "eu-west-3" => %{},
             "eu-north-1" => %{},
+            "me-south-1" => %{},
             "sa-east-1" => %{},
             "us-east-1" => %{},
             "us-east-2" => %{},


### PR DESCRIPTION
Add `me-south-1` to the list of SNS endpoints so ex_aws won't error when connecting to valid sns endpoints.

Before opening a PR, please make sure you have:

[x] Run `mix format` using a recent version of Elixir
[x] Run `mix dialyzer` to make sure the typing is correct
[x] Run `mix test` to ensure no tests have broken (also please make sure you've added tests for your particular change, where appropriate).

I couldn't find tests that check this particular use case. I would be more than happy to add any if required.