### PR TITLE
Add eu-central-2 to SQS endpoints

### DIFF
--- a/priv/endpoints.exs
+++ b/priv/endpoints.exs
@@ -1578,6 +1578,7 @@
             "ap-southeast-2" => %{},
             "ca-central-1" => %{},
             "eu-central-1" => %{},
+            "eu-central-2" => %{},
             "eu-west-1" => %{},
             "eu-west-2" => %{},
             "eu-west-3" => %{},


### PR DESCRIPTION
Adds SQS endpoint for eu-central-2 Europe (Zurich) 