### PR TITLE
Add eu-south-1 to SQS endpoints

### DIFF
--- a/priv/endpoints.exs
+++ b/priv/endpoints.exs
@@ -1600,6 +1600,7 @@
             "eu-west-2" => %{},
             "eu-west-3" => %{},
             "eu-north-1" => %{},
+            "eu-south-1" => %{},
             "fips-us-east-1" => %{},
             "fips-us-east-2" => %{},
             "fips-us-west-1" => %{},


### PR DESCRIPTION
Adding the eu-south-1 (Milan) region to the list of endpoints.