### PR TITLE
Ensure that response is transformed with all requests

### DIFF
--- a/lib/ex_aws/credentials_ini/file.ex
+++ b/lib/ex_aws/credentials_ini/file.ex
@@ -102,7 +102,7 @@ if Code.ensure_loaded?(ConfigParser) do
                 "",
                 [{"x-amz-sso_bearer_token", access_token}],
                 Map.get(config, :http_opts, [])
-              )},
+              ) |> ExAws.Request.maybe_transform_response()},
            {_, {:ok, body}} <- {:decode, config[:json_codec].decode(body_raw)} do
         {:ok, body}
       else

--- a/lib/ex_aws/credentials_ini/file.ex
+++ b/lib/ex_aws/credentials_ini/file.ex
@@ -102,7 +102,8 @@ if Code.ensure_loaded?(ConfigParser) do
                 "",
                 [{"x-amz-sso_bearer_token", access_token}],
                 Map.get(config, :http_opts, [])
-              ) |> ExAws.Request.maybe_transform_response()},
+              )
+              |> ExAws.Request.maybe_transform_response()},
            {_, {:ok, body}} <- {:decode, config[:json_codec].decode(body_raw)} do
         {:ok, body}
       else

--- a/lib/ex_aws/instance_meta.ex
+++ b/lib/ex_aws/instance_meta.ex
@@ -15,7 +15,7 @@ defmodule ExAws.InstanceMeta do
     # If we're using IMDSv2, we will need to pass in session token headers.
     headers = get_request_headers(config, fallback)
 
-    case config.http_client.request(:get, url, "", headers, http_opts()) do
+    case config.http_client.request(:get, url, "", headers, http_opts()) |> ExAws.Request.maybe_transform_response() do
       {:ok, %{status_code: 200, body: body}} ->
         body
 

--- a/lib/ex_aws/instance_meta.ex
+++ b/lib/ex_aws/instance_meta.ex
@@ -15,7 +15,8 @@ defmodule ExAws.InstanceMeta do
     # If we're using IMDSv2, we will need to pass in session token headers.
     headers = get_request_headers(config, fallback)
 
-    case config.http_client.request(:get, url, "", headers, http_opts()) |> ExAws.Request.maybe_transform_response() do
+    case config.http_client.request(:get, url, "", headers, http_opts())
+         |> ExAws.Request.maybe_transform_response() do
       {:ok, %{status_code: 200, body: body}} ->
         body
 

--- a/lib/ex_aws/instance_meta_token_provider.ex
+++ b/lib/ex_aws/instance_meta_token_provider.ex
@@ -82,7 +82,7 @@ defmodule ExAws.InstanceMetaTokenProvider do
            "",
            token_ttl_seconds_headers(config),
            follow_redirect: true
-         ) do
+        ) |> ExAws.Request.maybe_transform_response() do
       {:ok, %{status_code: 200, body: body}} ->
         body
 

--- a/lib/ex_aws/instance_meta_token_provider.ex
+++ b/lib/ex_aws/instance_meta_token_provider.ex
@@ -82,7 +82,8 @@ defmodule ExAws.InstanceMetaTokenProvider do
            "",
            token_ttl_seconds_headers(config),
            follow_redirect: true
-        ) |> ExAws.Request.maybe_transform_response() do
+         )
+         |> ExAws.Request.maybe_transform_response() do
       {:ok, %{status_code: 200, body: body}} ->
         body
 

--- a/lib/ex_aws/request.ex
+++ b/lib/ex_aws/request.ex
@@ -113,7 +113,7 @@ defmodule ExAws.Request do
           full_headers,
           Map.get(config, :http_opts, [])
         )
-        |> map_response()
+        |> maybe_transform_response()
 
       stop_metadata =
         case result do
@@ -138,14 +138,6 @@ defmodule ExAws.Request do
   defp extract_error({:ok, response}), do: response
   defp extract_error({:error, error}), do: error
   defp extract_error(error), do: error
-
-  defp map_response({:ok, %{status: status, body: body, headers: headers}}) do
-    # Req and Finch uses status as a key.
-
-    {:ok, %{status_code: status, body: body, headers: headers}}
-  end
-
-  defp map_response(response), do: response
 
   def client_error(%{status_code: status, body: body} = error, json_codec) do
     case json_codec.decode(body) do
@@ -218,4 +210,11 @@ defmodule ExAws.Request do
     |> :rand.uniform()
     |> :timer.sleep()
   end
+
+  def maybe_transform_response({:ok, %{status: status, body: body, headers: headers}}) do
+    # Req and Finch use status (rather than status_code) as a key.
+    {:ok, %{status_code: status, body: body, headers: headers}}
+  end
+
+  def maybe_transform_response(response), do: response
 end


### PR DESCRIPTION
### Issue

Thanks for the previous work to support Req in #976. Unfortunately it didn't _quite_ go far enough. There are a few more places that `.request` is called on the `http_client`, and they all need to have their responses transformed in case it's a Req response. 

### Necessary bits

- [x] Run `mix format` using a recent version of Elixir
- [x] Run `mix dialyzer` to make sure the typing is correct
- [x] Run `mix test` to ensure no tests have broken (also please make sure you've added tests for your particular change, where appropriate).
