### PR TITLE
Add some fips endpoints. Perhaps a fix for the partition regex.

### DIFF
--- a/lib/ex_aws/config/defaults.ex
+++ b/lib/ex_aws/config/defaults.ex
@@ -94,10 +94,6 @@ defmodule ExAws.Config.Defaults do
     |> Map.put(:host, host(service, region))
   end
 
-  # ExAws.Config.Defaults.host("sts", "us-east-1")
-  # Regex.run(~r/^(us|eu|af|ap|sa|ca|me)\-\w+-\d?-?\w+/, "us-east-1-fips")
-  # Regex.run(~r/^(us|eu|af|ap|sa|ca|me)\-\w+-\d?-?\w+/, "us-east-1")
-  # orig:     {~r/^(us|eu|af|ap|sa|ca|me)\-\w+\-\d+\-*$/, "aws"},
   @partitions [
     {~r/^(us|eu|af|ap|sa|ca|me)\-\w+-\d?-?\w+/, "aws"},
     {~r/^cn\-\w+\-\d+$/, "aws-cn"},
@@ -148,14 +144,11 @@ defmodule ExAws.Config.Defaults do
 
   defp do_host(partition, service_slug, region) do
     partition = @partition_data |> Map.fetch!(partition)
-
     partition_name = partition["partition"]
-
     service = service_map(service_slug)
 
     partition
     |> Map.fetch!("services")
-
     |> fetch_or(service, "#{service_slug} not found in partition #{partition_name}")
     |> case do
       %{"isRegionalized" => false} = data ->

--- a/lib/ex_aws/config/defaults.ex
+++ b/lib/ex_aws/config/defaults.ex
@@ -145,22 +145,18 @@ defmodule ExAws.Config.Defaults do
                   |> Map.new(fn partition ->
                     {partition["partition"], partition}
                   end)
-  def dbgg(x,f) do
-    File.write!("#{f}.txt", Jason.encode!(x))
-    x
-  end
 
   defp do_host(partition, service_slug, region) do
     partition = @partition_data |> Map.fetch!(partition)
-    dbgg(partition,"partition")
-    partition_name = partition["partition"] |> IO.inspect(label: "partition_name")
 
-    service = service_map(service_slug) |> IO.inspect(label: "service")
+    partition_name = partition["partition"]
+
+    service = service_map(service_slug)
 
     partition
     |> Map.fetch!("services")
-    |> dbgg("services")
-    |> fetch_or(service, "#{service_slug} not found in partition #{partition_name}") |> IO.inspect(label: "fetch_or")
+
+    |> fetch_or(service, "#{service_slug} not found in partition #{partition_name}")
     |> case do
       %{"isRegionalized" => false} = data ->
         data

--- a/lib/ex_aws/config/defaults.ex
+++ b/lib/ex_aws/config/defaults.ex
@@ -95,7 +95,7 @@ defmodule ExAws.Config.Defaults do
   end
 
   @partitions [
-    {~r/^(us|eu|af|ap|sa|ca|me)\-\w+-\d?-?\w+/, "aws"},
+    {~r/^(us|eu|af|ap|sa|ca|me)\-\w+-\d?-?\w+$/, "aws"},
     {~r/^cn\-\w+\-\d+$/, "aws-cn"},
     {~r/^us\-gov\-\w+\-\d+$/, "aws-us-gov"}
   ]
@@ -105,7 +105,6 @@ defmodule ExAws.Config.Defaults do
       Enum.find(@partitions, fn {regex, _} ->
         Regex.run(regex, region)
       end)
-      |> IO.inspect(label: "partition")
 
     with {_, partition} <- partition do
       do_host(partition, service, region)

--- a/lib/ex_aws/config/defaults.ex
+++ b/lib/ex_aws/config/defaults.ex
@@ -94,8 +94,12 @@ defmodule ExAws.Config.Defaults do
     |> Map.put(:host, host(service, region))
   end
 
+  # ExAws.Config.Defaults.host("sts", "us-east-1")
+  # Regex.run(~r/^(us|eu|af|ap|sa|ca|me)\-\w+-\d?-?\w+/, "us-east-1-fips")
+  # Regex.run(~r/^(us|eu|af|ap|sa|ca|me)\-\w+-\d?-?\w+/, "us-east-1")
+  # orig:     {~r/^(us|eu|af|ap|sa|ca|me)\-\w+\-\d+\-*$/, "aws"},
   @partitions [
-    {~r/^(us|eu|af|ap|sa|ca|me)\-\w+\-\d+$/, "aws"},
+    {~r/^(us|eu|af|ap|sa|ca|me)\-\w+-\d?-?\w+/, "aws"},
     {~r/^cn\-\w+\-\d+$/, "aws-cn"},
     {~r/^us\-gov\-\w+\-\d+$/, "aws-us-gov"}
   ]
@@ -105,6 +109,7 @@ defmodule ExAws.Config.Defaults do
       Enum.find(@partitions, fn {regex, _} ->
         Regex.run(regex, region)
       end)
+      |> IO.inspect(label: "partition")
 
     with {_, partition} <- partition do
       do_host(partition, service, region)
@@ -140,16 +145,22 @@ defmodule ExAws.Config.Defaults do
                   |> Map.new(fn partition ->
                     {partition["partition"], partition}
                   end)
+  def dbgg(x,f) do
+    File.write!("#{f}.txt", Jason.encode!(x))
+    x
+  end
 
   defp do_host(partition, service_slug, region) do
     partition = @partition_data |> Map.fetch!(partition)
-    partition_name = partition["partition"]
+    dbgg(partition,"partition")
+    partition_name = partition["partition"] |> IO.inspect(label: "partition_name")
 
-    service = service_map(service_slug)
+    service = service_map(service_slug) |> IO.inspect(label: "service")
 
     partition
     |> Map.fetch!("services")
-    |> fetch_or(service, "#{service_slug} not found in partition #{partition_name}")
+    |> dbgg("services")
+    |> fetch_or(service, "#{service_slug} not found in partition #{partition_name}") |> IO.inspect(label: "fetch_or")
     |> case do
       %{"isRegionalized" => false} = data ->
         data

--- a/priv/endpoints.exs
+++ b/priv/endpoints.exs
@@ -1444,6 +1444,7 @@
               "hostname" => "s3.sa-east-1.amazonaws.com",
               "signatureVersions" => ["s3", "s3v4"]
             },
+            "us-east-1-fips" => %{},
             "us-east-1" => %{
               "hostname" => "s3.amazonaws.com",
               "signatureVersions" => ["s3", "s3v4"]

--- a/priv/endpoints.exs
+++ b/priv/endpoints.exs
@@ -1040,6 +1040,11 @@
             "eu-north-1" => %{},
             "sa-east-1" => %{},
             "us-east-1" => %{"sslCommonName" => "{service}.{dnsSuffix}"},
+            "us-east-1-fips" => %{
+              "sslCommonName" => "{service}.{dnsSuffix}",
+              "hostname" => "rds-fips.us-east-1.amazonaws.com",
+              "credentialScope" => %{"region" => "us-east-1"}
+            },
             "us-east-2" => %{},
             "us-west-1" => %{},
             "us-west-2" => %{}

--- a/priv/endpoints.exs
+++ b/priv/endpoints.exs
@@ -978,7 +978,10 @@
             "eu-north-1" => %{},
             "sa-east-1" => %{},
             "us-east-1" => %{},
-            "us-east-1-fips" => %{},
+            "us-east-1-fips" => %{
+              "hostname" => "kms-fips.us-east-1.amazonaws.com",
+              "credentialScope" => %{"region" => "us-east-1"}
+            },
             "us-east-2" => %{},
             "us-west-1" => %{},
             "us-west-2" => %{}
@@ -1444,7 +1447,10 @@
               "hostname" => "s3.sa-east-1.amazonaws.com",
               "signatureVersions" => ["s3", "s3v4"]
             },
-            "us-east-1-fips" => %{},
+            "us-east-1-fips" => %{
+              "hostname" => "s3-fips.us-east-1.amazonaws.com",
+              "credentialScope" => %{"region" => "us-east-1"}
+            },
             "us-east-1" => %{
               "hostname" => "s3.amazonaws.com",
               "signatureVersions" => ["s3", "s3v4"]

--- a/priv/endpoints.exs
+++ b/priv/endpoints.exs
@@ -978,6 +978,7 @@
             "eu-north-1" => %{},
             "sa-east-1" => %{},
             "us-east-1" => %{},
+            "us-east-1-fips" => %{},
             "us-east-2" => %{},
             "us-west-1" => %{},
             "us-west-2" => %{}


### PR DESCRIPTION
On _main_
`ExAws.Config.Defaults.host("sts", "us-east-1-fips")` would return `nil`.
With this PR, it returns
`"sts-fips.us-east-1.amazonaws.com"`

Plus,

Some endpoints are added.