### PR TITLE
Update request logic to handle error reasons in keyword lists

### DIFF
--- a/lib/ex_aws/request.ex
+++ b/lib/ex_aws/request.ex
@@ -74,7 +74,13 @@ defmodule ExAws.Request do
             attempt_again?(attempt, reason, config)
           )
 
-        {:error, %{reason: reason}} ->
+        {:error, reason_struct} ->
+          reason =
+            case reason_struct do
+              %{reason: reason} -> reason
+              [reason: reason] -> reason
+            end
+
           Logger.warning(
             "ExAws: HTTP ERROR: #{inspect(reason)} for URL: #{inspect(safe_url)} ATTEMPT: #{attempt}"
           )

--- a/test/ex_aws/request_test.exs
+++ b/test/ex_aws/request_test.exs
@@ -204,4 +204,50 @@ defmodule ExAws.RequestTest do
                {:attempt, 1}
              )
   end
+
+  test "Retries on errors, when the error reason is a map", context do
+    ExAws.Request.HttpMock
+    |> expect(:request, fn _method, _url, _body, _headers, _opts ->
+      {:error, %{reason: :closed}}
+    end)
+
+    http_method = :get
+    url = "https://examplebucket.s3.amazonaws.com/test.txt"
+    service = :s3
+    request_body = ""
+
+    assert {:error, :closed} ==
+             ExAws.Request.request_and_retry(
+               http_method,
+               url,
+               service,
+               context[:config],
+               context[:headers],
+               request_body,
+               {:attempt, 5}
+             )
+  end
+
+  test "Retries on errors, when the error reason is a keyword list", context do
+    ExAws.Request.HttpMock
+    |> expect(:request, fn _method, _url, _body, _headers, _opts ->
+      {:error, [reason: :closed]}
+    end)
+
+    http_method = :get
+    url = "https://examplebucket.s3.amazonaws.com/test.txt"
+    service = :s3
+    request_body = ""
+
+    assert {:error, :closed} ==
+             ExAws.Request.request_and_retry(
+               http_method,
+               url,
+               service,
+               context[:config],
+               context[:headers],
+               request_body,
+               {:attempt, 5}
+             )
+  end
 end


### PR DESCRIPTION
Fixes https://github.com/ex-aws/ex_aws/issues/1005 by updating `request.ex` to also handle errors in the form of `[reason: reason]` in addition to `%{reason: reason}`.

[x] Run `mix format` using a recent version of Elixir
[x] Run `mix dialyzer` to make sure the typing is correct
[x] Run `mix test` to ensure no tests have broken (also please make sure you've added tests for your particular change, where appropriate).
