### PR TITLE
Adds the ssm-incidents and ssm-contacts to the endpoints.exs

### DIFF
--- a/priv/endpoints.exs
+++ b/priv/endpoints.exs
@@ -1186,6 +1186,48 @@
             "us-west-2" => %{}
           }
         },
+        "ssm-incidents" => %{
+          "endpoints" => %{
+            "ap-northeast-1" => %{},
+            "ap-northeast-2" => %{},
+            "ap-east-1" => %{},
+            "ap-south-1" => %{},
+            "ap-southeast-1" => %{},
+            "ap-southeast-2" => %{},
+            "ca-central-1" => %{},
+            "eu-central-1" => %{},
+            "eu-west-1" => %{},
+            "eu-west-2" => %{},
+            "eu-west-3" => %{},
+            "eu-north-1" => %{},
+            "sa-east-1" => %{},
+            "us-east-1" => %{},
+            "us-east-2" => %{},
+            "us-west-1" => %{},
+            "us-west-2" => %{}
+          }
+        },
+        "ssm-contacts" => %{
+          "endpoints" => %{
+            "ap-northeast-1" => %{},
+            "ap-northeast-2" => %{},
+            "ap-east-1" => %{},
+            "ap-south-1" => %{},
+            "ap-southeast-1" => %{},
+            "ap-southeast-2" => %{},
+            "ca-central-1" => %{},
+            "eu-central-1" => %{},
+            "eu-west-1" => %{},
+            "eu-west-2" => %{},
+            "eu-west-3" => %{},
+            "eu-north-1" => %{},
+            "sa-east-1" => %{},
+            "us-east-1" => %{},
+            "us-east-2" => %{},
+            "us-west-1" => %{},
+            "us-west-2" => %{}
+          }
+        },
         "servicediscovery" => %{
           "endpoints" => %{
             "ap-northeast-1" => %{},


### PR DESCRIPTION
I am building a ex_aws_incidents lib and those two endpoints are required.

Here are they in the aws-sdk-go: [ssm-incidents](https://github.com/aws/aws-sdk-go/blob/main/models/apis/ssm-incidents/2018-05-10/api-2.json) & [ssm-contacts](https://github.com/aws/aws-sdk-go/blob/main/models/apis/ssm-contacts/2021-05-03/api-2.json)
