### PR TITLE
Fix s3 gov-us-east-1 and gov-us-west-1 URLs.

### DIFF
--- a/priv/endpoints.exs
+++ b/priv/endpoints.exs
@@ -2642,11 +2642,11 @@
               "hostname" => "s3-fips.us-gov-west-1.amazonaws.com"
             },
             "us-gov-east-1" => %{
-              "hostname" => "s3.us-gov-east-1.amazonaws.com",
+              "hostname" => "s3-fips.us-gov-east-1.amazonaws.com",
               "protocols" => ["http", "https"]
             },
             "us-gov-west-1" => %{
-              "hostname" => "s3.us-gov-west-1.amazonaws.com",
+              "hostname" => "s3-fips.us-gov-west-1.amazonaws.com",
               "protocols" => ["http", "https"]
             }
           }


### PR DESCRIPTION
Govcloud uses FIPS endpoint. The URL references are here according to AWS docs:


https://aws.amazon.com/compliance/fips/


![Screenshot 2023-12-01 at 15 45 09](https://github.com/ex-aws/ex_aws/assets/1039486/e709332b-a433-4c75-9c2c-6c1ff790bb04)
