### PR TITLE
Add `me-south-1` to s3 endpoints

### DIFF
--- a/priv/endpoints.exs
+++ b/priv/endpoints.exs
@@ -1530,6 +1530,7 @@
             "eu-west-3" => %{},
             "eu-north-1" => %{},
             "me-central-1" => %{},
+            "me-south-1" => %{},
             "s3-external-1" => %{
               "credentialScope" => %{"region" => "us-east-1"},
               "hostname" => "s3-external-1.amazonaws.com",


### PR DESCRIPTION
`me-south-1` is supported in the `aws` partition as can be seen here: https://docs.aws.amazon.com/general/latest/gr/s3.html

Before opening a PR, please make sure you have:

* Run `mix format` using a recent version of Elixir (check)
* Run `mix dialyzer` to make sure the typing is correct (check)
* Run `mix test` to ensure no tests have broken (also please make sure you've added tests for your particular change, where appropriate). (check)
