### PR TITLE
sso_session support in .aws/config

### DIFF
--- a/lib/ex_aws/credentials_ini/file.ex
+++ b/lib/ex_aws/credentials_ini/file.ex
@@ -9,9 +9,7 @@ if Code.ensure_loaded?(ConfigParser) do
       sso_start_url sso_region sso_account_id sso_role_name
     )
 
-    @special_merge_keys ~w(
-      sso_session services
-    )
+    @special_merge_keys ~w(sso_session)
 
     def security_credentials(profile_name) do
       config_credentials = profile_from_config(profile_name)

--- a/test/ex_aws/credentials_ini/file_test.exs
+++ b/test/ex_aws/credentials_ini/file_test.exs
@@ -37,6 +37,28 @@ defmodule ExAws.CredentialsIni.File.FileTest do
     assert config.sso_role_name == "SomeRole"
   end
 
+  test "config file is parsed with sso config that uses sso_session" do
+    example_config = """
+    [sso-session somecompany]
+    sso_start_url = https://start.us-gov-home.awsapps.com/directory/somecompany
+    sso_region = us-gov-west-1
+
+    [default]
+    sso_session = somecompany
+    sso_account_id = 123456789101
+    sso_role_name = SomeRole
+    region = us-gov-west-1
+    output = json
+    """
+
+    config = ExAws.CredentialsIni.File.parse_ini_file({:ok, example_config}, "default")
+
+    assert config.sso_start_url == "https://start.us-gov-home.awsapps.com/directory/somecompany"
+    assert config.sso_region == "us-gov-west-1"
+    assert config.sso_account_id == "123456789101"
+    assert config.sso_role_name == "SomeRole"
+  end
+
   test "{:system} in profile name gets dynamic profile name" do
     System.put_env("AWS_PROFILE", "custom-profile")
 

--- a/test/ex_aws/credentials_ini/file_test.exs
+++ b/test/ex_aws/credentials_ini/file_test.exs
@@ -53,6 +53,7 @@ defmodule ExAws.CredentialsIni.File.FileTest do
 
     config = ExAws.CredentialsIni.File.parse_ini_file({:ok, example_config}, "default")
 
+    assert config.sso_session == "somecompany"
     assert config.sso_start_url == "https://start.us-gov-home.awsapps.com/directory/somecompany"
     assert config.sso_region == "us-gov-west-1"
     assert config.sso_account_id == "123456789101"


### PR DESCRIPTION
This makes sso_session in ~/.aws/config work properly. See issue #951
It simply merges in the config entries from the specified sso-session section. It also changes the cache_key used from sso_start_url to the sso_session name when sso_session is specified.