### PR TITLE
Add Req request backend

### DIFF
--- a/lib/ex_aws/request/req.ex
+++ b/lib/ex_aws/request/req.ex
@@ -1,0 +1,31 @@
+defmodule ExAws.Request.Req do
+  @behaviour ExAws.Request.HttpClient
+
+  @moduledoc """
+  Configuration for `m:Req`.
+
+  Options can be set for `m:Req` with the following config:
+
+      config :ex_aws, :req_opts,
+        receive_timeout: 30_000
+
+  The default config handles setting the above.
+  """
+
+  @default_opts [receive_timeout: 30_000]
+
+  @impl true
+  def request(method, url, body \\ "", headers \\ [], http_opts \\ []) do
+    [method: method, url: url, body: body, headers: headers, decode_body: false]
+    |> Keyword.merge(Application.get_env(:ex_aws, :req_opts, @default_opts))
+    |> Keyword.merge(http_opts)
+    |> Req.request()
+    |> case do
+      {:ok, %{status: status, headers: headers, body: body}} ->
+        {:ok, %{status_code: status, headers: headers, body: body}}
+
+      {:error, reason} ->
+        {:error, %{reason: reason}}
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -46,12 +46,12 @@ defmodule ExAws.Mixfile do
       {:dialyxir, "~> 1.0", only: [:dev, :test], runtime: false},
       {:ex_doc, "~> 0.16", only: [:dev, :test]},
       {:hackney, "~> 1.16", optional: true},
+      {:req, "~> 0.3", optional: true},
       {:jason, "~> 1.1", optional: true},
       {:jsx, "~> 2.8 or ~> 3.0", optional: true},
       {:mox, "~> 1.0", only: :test},
       {:sweet_xml, "~> 0.7", optional: true},
-      {:excoveralls, "~> 0.10", only: :test},
-      {:req, "~> 0.3", only: :test}
+      {:excoveralls, "~> 0.10", only: :test}
     ]
   end
 


### PR DESCRIPTION
When communicating with storage backends over a local socket (using sendfile, responses are not limited to small chunks), hackney does not reliably handle responses above about 64MiB - see https://github.com/benoitc/hackney/issues/729

This adds a Req backend. Req is widely used and does not have such a limitation.