### PR TITLE
Don't set content-length header for HEAD requests with empty body

### DIFF
--- a/lib/ex_aws/operation/s3.ex
+++ b/lib/ex_aws/operation/s3.ex
@@ -46,6 +46,8 @@ defmodule ExAws.Operation.S3 do
 
     defp put_content_length_header(headers, "", :get), do: headers
 
+    defp put_content_length_header(headers, "", :head), do: headers
+
     defp put_content_length_header(headers, body, _) do
       Map.put(headers, "content-length", IO.iodata_length(body) |> Integer.to_string())
     end

--- a/lib/ex_aws/operation/s3.ex
+++ b/lib/ex_aws/operation/s3.ex
@@ -48,6 +48,8 @@ defmodule ExAws.Operation.S3 do
 
     defp put_content_length_header(headers, "", :head), do: headers
 
+    defp put_content_length_header(headers, "", :delete), do: headers
+
     defp put_content_length_header(headers, body, _) do
       Map.put(headers, "content-length", IO.iodata_length(body) |> Integer.to_string())
     end


### PR DESCRIPTION
```elixir
defp put_content_length_header(headers, "", :head), do: headers
```

This extra function clause in `lib/ex_aws/operation/s3.ex` prevents the `content-length` header from being added to the headers of a `HEAD` request with an empty body (in which case the body of the request is an empty string and the value of that header would be "0"). 

This is compliant with [Amazon's specification of the HeadObject API endpoint](https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadObject.html#API_HeadObject_RequestParameters), as it doesn't specify the `content-length` header as part of the URI Request Parameters.

As an added benefit, this makes ExAws and ExAws.S3 work with [Garage](https://garagehq.deuxfleurs.fr/). Unlike [Minio](https://min.io), Garage doesn't gracefully handle the extraneous presence of the `{"content-length", "0"}` header in the request headers of the HeadObject call.

[x] Run `mix format` using a recent version of Elixir
[x] Run `mix dialyzer` to make sure the typing is correct
[x] Run `mix test` to ensure no tests have broken (also please make sure you've added tests for your particular change, where appropriate) (no new tests added)
