### PR TITLE
support sso credentials with profile in section name

### DIFF
--- a/lib/ex_aws/credentials_ini/file.ex
+++ b/lib/ex_aws/credentials_ini/file.ex
@@ -227,6 +227,8 @@ if Code.ensure_loaded?(ConfigParser) do
     end
 
     def parse_ini_file({:ok, contents}, profile_name) do
+      composite_key = "profile " <> profile_name
+
       contents
       |> ConfigParser.parse_string()
       |> case do
@@ -234,7 +236,7 @@ if Code.ensure_loaded?(ConfigParser) do
           merge_special_keys(full, config)
           |> strip_key_prefix()
 
-        {:ok, %{("profile " <> ^profile_name) => config} = full} ->
+        {:ok, %{^composite_key => config} = full} ->
           merge_special_keys(full, config)
           |> strip_key_prefix()
 

--- a/lib/ex_aws/credentials_ini/file.ex
+++ b/lib/ex_aws/credentials_ini/file.ex
@@ -234,6 +234,10 @@ if Code.ensure_loaded?(ConfigParser) do
           merge_special_keys(full, config)
           |> strip_key_prefix()
 
+        {:ok, %{("profile " <> ^profile_name) => config} = full} ->
+          merge_special_keys(full, config)
+          |> strip_key_prefix()
+
         {:ok, %{}} ->
           %{}
 


### PR DESCRIPTION
Running `aws configure sso` produces a profile similar to

```
[profile mycompany]
sso_session = mycompanysso
sso_account_id = 111111111111
sso_role_name = ReadOnly
region = us-east-2
output = json
[sso-session mycompanysso]
sso_start_url = https://mycompanysso.awsapps.com/start
sso_region = us-east-1
sso_registration_scopes = sso:account:access
```

I'm pretty sure this
closes #951
