### PR TITLE
update tests, erlang 27, elixir 1.17, ubuntu 24.04

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -52,13 +52,6 @@ jobs:
               otp: 24.x
               elixir: 1.13.x
 
-          - pair:
-              otp: 23.x
-              elixir: 1.14.x
-          - pair:
-              otp: 23.x
-              elixir: 1.13.x
-
     steps:
       - uses: actions/checkout@v4
       - uses: erlef/setup-beam@v1

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -12,21 +12,36 @@ jobs:
       matrix:
         include:
           - pair:
+              otp: 27.x
+              elixir: 1.17.x
+              lint: lint
+
+          - pair:
+              otp: 26.x
+              elixir: 1.17.x
+          - pair:
               otp: 26.x
               elixir: 1.16.x
-              lint: lint
           - pair:
               otp: 26.x
               elixir: 1.15.x
+
+          - pair:
+              otp: 25.x
+              elixir: 1.17.x
+          - pair:
+              otp: 25.x
+              elixir: 1.16.x
           - pair:
               otp: 25.x
               elixir: 1.15.x
           - pair:
               otp: 25.x
               elixir: 1.14.x
+
           - pair:
-              otp: 25.x
-              elixir: 1.13.x
+              otp: 24.x
+              elixir: 1.16.x
           - pair:
               otp: 24.x
               elixir: 1.15.x
@@ -36,18 +51,13 @@ jobs:
           - pair:
               otp: 24.x
               elixir: 1.13.x
-          - pair:
-              otp: 24.x
-              elixir: 1.12.x
+
           - pair:
               otp: 23.x
               elixir: 1.14.x
           - pair:
               otp: 23.x
               elixir: 1.13.x
-          - pair:
-              otp: 23.x
-              elixir: 1.12.x
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -6,7 +6,7 @@ env:
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     # See https://hexdocs.pm/elixir/compatibility-and-deprecations.html#compatibility-between-elixir-and-erlang-otp
     strategy:
       matrix:


### PR DESCRIPTION
- **tests: update elixir/erlang test matrix**
- **tests: use ubuntu 24.04**

Dropped unsupported elixir versions, added a couple missing ones, and the newest versions. Bumped the ubuntu version to the latest LTS.