### PR TITLE
Add Codeartifact to endpoints

### DIFF
--- a/priv/endpoints.exs
+++ b/priv/endpoints.exs
@@ -168,6 +168,23 @@ chime_voice_regions = [
             "us-west-2" => %{}
           }
         },
+        "codeartifact" => %{
+          "endpoints" => %{
+            "us-east-1" => %{},
+            "us-east-2" => %{},
+            "us-west-2" => %{},
+            "eu-west-1" => %{},
+            "eu-west-2" => %{},
+            "eu-west-3" => %{},
+            "eu-central-1" => %{},
+            "eu-north-1" => %{},
+            "eu-south-1" => %{},
+            "ap-southeast-1" => %{},
+            "ap-southeast-2" => %{},
+            "ap-northeast-1" => %{},
+            "ap-south-1" => %{}
+          }
+        },
         "firehose" => %{
           "endpoints" => %{
             "af-south-1" => %{},


### PR DESCRIPTION
This allows `ExAws.Config.new(:codeartifact)` to run without throwing an error.