### PR TITLE
Add/fix hostname of us-gov-west-1.

### DIFF
--- a/priv/endpoints.exs
+++ b/priv/endpoints.exs
@@ -3126,7 +3126,10 @@ chime_voice_regions = [
               "hostname" => "kms-fips.us-gov-east-1.amazonaws.com",
               "credentialScope" => %{"region" => "us-gov-east-1"}
             },
-            "us-gov-west-1" => %{}
+            "us-gov-west-1" => %{
+              "hostname" => "kms-fips.us-gov-west-1.amazonaws.com",
+              "credentialScope" => %{"region" => "us-gov-west-1"}
+            }
           }
         },
         "sms" => %{"endpoints" => %{"us-gov-east-1" => %{}, "us-gov-west-1" => %{}}},


### PR DESCRIPTION
Issue, demonstrated via comparing against us-gov-east-1 which works as desired:
<img width="460" alt="Screenshot 2024-10-07 at 14 47 03" src="https://github.com/user-attachments/assets/fc951424-0f76-4a11-ae0e-675940e358a6">

Desire according to [aws documentation](https://aws.amazon.com/compliance/fips/#FIPS_Endpoints_by_Service):
![image](https://github.com/user-attachments/assets/fae514bc-8714-4c17-9d48-7153f2b9f61f)

This pull-request brings:
<img width="462" alt="Screenshot 2024-10-07 at 14 56 44" src="https://github.com/user-attachments/assets/348e3a75-ce02-4c9f-845b-382a7e9d9632">


