### PR TITLE
Configurable max attempts for client errors

### DIFF
--- a/priv/endpoints.exs
+++ b/priv/endpoints.exs
@@ -168,6 +168,23 @@ chime_voice_regions = [
             "us-west-2" => %{}
           }
         },
+        "codeartifact" => %{
+          "endpoints" => %{
+            "us-east-1" => %{},
+            "us-east-2" => %{},
+            "us-west-2" => %{},
+            "eu-west-1" => %{},
+            "eu-west-2" => %{},
+            "eu-west-3" => %{},
+            "eu-central-1" => %{},
+            "eu-north-1" => %{},
+            "eu-south-1" => %{},
+            "ap-southeast-1" => %{},
+            "ap-southeast-2" => %{},
+            "ap-northeast-1" => %{},
+            "ap-south-1" => %{}
+          }
+        },
         "firehose" => %{
           "endpoints" => %{
             "af-south-1" => %{},

--- a/priv/endpoints.exs
+++ b/priv/endpoints.exs
@@ -1837,6 +1837,7 @@ chime_voice_regions = [
             "eu-west-2" => %{},
             "eu-west-3" => %{},
             "eu-north-1" => %{},
+            "il-central-1" => %{},
             "me-central-1" => %{},
             "me-south-1" => %{},
             "s3-external-1" => %{
@@ -2066,6 +2067,7 @@ chime_voice_regions = [
             "ca-central-1" => %{},
             "ap-southeast-1" => %{},
             "ap-southeast-2" => %{},
+            "eu-central-1" => %{},
             "eu-west-1" => %{},
             "eu-west-2" => %{}
           }


### PR DESCRIPTION
We want to be able to apply different retry strategies depending on the error type we get back from AWS.
More specifically:
  1. We don't want to retry throughput exceeded errors to fail fast in case we temporarily overloaded AWS and bubble up the backpressure to the caller.
  2. If AWS has some internal problems and returns 500 errors for a few seconds, we want to retry them.

This PR proposes a naive approach to enabling different `max_attempts` to be applied to the client errors (`400..499`).

A more sophisticated approach is to override the whole retry strategy (including backoff values) for specific errors or error ranges.