### PR TITLE
Fix Req :follow_redirects deprecation warning

### DIFF
--- a/lib/ex_aws/request/req.ex
+++ b/lib/ex_aws/request/req.ex
@@ -36,6 +36,6 @@ defmodule ExAws.Request.Req do
   defp rename_follow_redirect(opts) do
     {follow, opts} = Keyword.pop(opts, :follow_redirect, false)
 
-    Keyword.put(opts, :follow_redirects, follow)
+    Keyword.put(opts, :redirect, follow)
   end
 end


### PR DESCRIPTION
Fixes the below deprecation warnings from Req:
```
warning: :follow_redirects option has been renamed to :redirect
  (req 0.5.7) lib/req/steps.ex:1794: Req.Steps.redirect/1
  (req 0.5.7) lib/req/request.ex:1120: anonymous fn/2 in Req.Request.run_response/2
  (elixir 1.17.3) lib/enum.ex:4858: Enumerable.List.reduce/3
  (elixir 1.17.3) lib/enum.ex:2585: Enum.reduce_while/3
  (req 0.5.7) lib/req/request.ex:1047: Req.Request.run/1
  (ex_aws 2.5.7) lib/ex_aws/request/req.ex:24: ExAws.Request.Req.request/5
```

`:follow_redirects` has been deprecated since `v0.4.0` per https://hexdocs.pm/req/changelog.html#v0-4-0-2023-09-01