### PR TITLE
Add SQS endpoint for me-central-1

### DIFF
--- a/priv/endpoints.exs
+++ b/priv/endpoints.exs
@@ -2069,6 +2069,7 @@ chime_voice_regions = [
             "fips-us-east-2" => %{},
             "fips-us-west-1" => %{},
             "fips-us-west-2" => %{},
+            "me-central-1" => %{},
             "me-south-1" => %{},
             "sa-east-1" => %{},
             "us-east-1" => %{"sslCommonName" => "queue.{dnsSuffix}"},


### PR DESCRIPTION
## Changes

Confirmation on the SQS region availability:

1. AWS regions for SQS - https://docs.aws.amazon.com/general/latest/gr/sqs-service.html#sqs_region
2. Boto Core - https://github.com/boto/botocore/blob/develop/botocore/data/endpoints.json#L22454


### Checks 

- [x] Run `mix format` using a recent version of Elixir
- [x] Run `mix dialyzer` to make sure the typing is correct
- [x] Run `mix test` to ensure no tests have broken (also please make sure you've added tests for your particular change, where appropriate).
