### PR TITLE
Add eu-central-2 to CloudFormation endpoints

### DIFF
--- a/priv/endpoints.exs
+++ b/priv/endpoints.exs
@@ -2618,6 +2618,7 @@ chime_voice_regions = [
             "ca-central-1" => %{},
             "ca-west-1" => %{},
             "eu-central-1" => %{},
+            "eu-central-2" => %{},
             "eu-west-1" => %{},
             "eu-west-2" => %{},
             "eu-west-3" => %{},


### PR DESCRIPTION
This pull request adds support for the AWS region eu-central-2 (Europe, Zurich) in the ExAws library. The eu-central-2 region was officially launched in 2022 and supports AWS CloudFormation. By incorporating this region, users can now utilize ExAws to manage AWS services within the Zurich region.​

CloudFormation is indeed supported in the eu-central-2 region: https://docs.aws.amazon.com/general/latest/gr/cfn.html