### PR TITLE
Add stream_builder to RestQuery, fix Operation.stream implementation

### DIFF
--- a/lib/ex_aws/operation/rest_query.ex
+++ b/lib/ex_aws/operation/rest_query.ex
@@ -1,7 +1,8 @@
 defmodule ExAws.Operation.RestQuery do
   @moduledoc false
 
-  defstruct http_method: nil,
+  defstruct stream_builder: nil,
+            http_method: nil,
             path: "/",
             params: %{},
             body: "",
@@ -29,7 +30,13 @@ defimpl ExAws.Operation, for: ExAws.Operation.RestQuery do
     |> operation.parser.(operation.action)
   end
 
-  def stream!(%{stream_builder: fun}, config) do
-    fun.(config)
+  def stream!(%ExAws.Operation.RestQuery{stream_builder: nil}, _) do
+    raise ArgumentError, """
+    This operation does not support streaming!
+    """
+  end
+
+  def stream!(%ExAws.Operation.RestQuery{stream_builder: stream_builder}, config_overrides) do
+    stream_builder.(config_overrides)
   end
 end


### PR DESCRIPTION
This PR adds `stream_builder` property to `RestQuery`. The `stream!` implementation added in https://github.com/ex-aws/ex_aws/commit/6cc2365b24ab71551840924220026e86495710ac could never work as intended. To fix it I added an implementation similar to the one in `Json` https://github.com/ex-aws/ex_aws/blob/main/lib/ex_aws/operation/json.ex#L63

Fixes a type system warning:
```
    warning: the 1st pattern in clause will never match:

        %{stream_builder: fun}

    because it is expected to receive type:

        dynamic(%ExAws.Operation.RestQuery{})

    typing violation found at:
    │
 32 │   def stream!(%{stream_builder: fun}, config) do
    │               ~
    │
    └─ (ex_aws 2.5.8) lib/ex_aws/operation/rest_query.ex:32:15: ExAws.Operation.ExAws.Operation.RestQuery.stream!/2
```
