### PR TITLE
Fix crash on SSO credentials error

### DIFF
--- a/lib/ex_aws/credentials_ini/file.ex
+++ b/lib/ex_aws/credentials_ini/file.ex
@@ -111,7 +111,7 @@ if Code.ensure_loaded?(ConfigParser) do
         {:ok, body}
       else
         {:request, {_, %{status_code: status_code} = resp}} ->
-          {:error, "SSO role credentials request responded with #{status_code}: #{resp}"}
+          {:error, "SSO role credentials request responded with #{status_code}: #{inspect(resp)}"}
 
         {:decode, err} ->
           {:error, "Could not decode SSO role credentials response: #{err}"}


### PR DESCRIPTION
Fixes typesystem warning:
```
     warning: incompatible value given to string interpolation:

         resp

     it has type:

         dynamic(%{..., status_code: term()})

     but expected a type that implements the String.Chars protocol, it must be one of:

         dynamic(
           %Date{} or %DateTime{} or %NaiveDateTime{} or %Time{} or %URI{} or %Version{} or
             %Version.Requirement{}
         ) or atom() or binary() or empty_list() or float() or integer() or non_empty_list(term(), term())

     where "resp" was given the type:

         # type: dynamic(%{..., status_code: term()})
         # from: lib/ex_aws/credentials_ini/file.ex
         {:request, {_, %{status_code: status_code} = resp}}

     hint: string interpolation uses the String.Chars protocol to convert a data structure into a string. Either convert the data type into a string upfront or implement the protocol accordingly

     typing violation found at:
     │
 114 │           {:error, "SSO role credentials request responded with #{status_code}: #{resp}"}
     │           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     │
     └─ lib/ex_aws/credentials_ini/file.ex:114: ExAws.CredentialsIni.File.request_sso_role_credentials/5
```