### PR TITLE
Fix build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <!-- MDOC !-->
 
-![GitHub Workflow Status](https://img.shields.io/github/workflow/status/ex-aws/ex_aws/on-push)
+[![GitHub Workflow Status](https://github.com/ex-aws/ex_aws/actions/workflows/on-push.yml/badge.svg)](https://github.com/ex-aws/ex_aws/actions/workflows/on-push.yml)
 [![hex.pm](https://img.shields.io/hexpm/v/ex_aws.svg)](https://hex.pm/packages/ex_aws)
 [![hex.pm](https://img.shields.io/hexpm/dt/ex_aws.svg)](https://hex.pm/packages/ex_aws)
 [![hex.pm](https://img.shields.io/hexpm/l/ex_aws.svg)](https://hex.pm/packages/ex_aws)


### PR DESCRIPTION
Seemed broken for me when I checked out the github.

![image](https://github.com/user-attachments/assets/1d066f3b-c7d1-4a56-ad8a-06d00007e34b)


with this it looks fine/as it should :)

Here's a small side by side:

![image](https://github.com/user-attachments/assets/3b5bca27-bc05-4635-aa92-9a75a0a386f9)


Thanks for ExAws!