### PR TITLE
Add bedrock endpoints to gov cloud partition

### DIFF
--- a/priv/endpoints.exs
+++ b/priv/endpoints.exs
@@ -3122,6 +3122,65 @@ chime_voice_regions = [
         "us-gov-west-1" => %{"description" => "AWS GovCloud (US-West)"}
       },
       "services" => %{
+        "bedrock" => %{
+          "endpoints" => %{
+            "us-gov-east-1" => %{},
+            "us-gov-east-1-fips" => %{
+              "credentialScope" => %{"region" => "us-gov-east-1"},
+              "hostname" => "bedrock-fips.us-gov-east-1.amazonaws.com"
+            },
+            "us-gov-west-1" => %{},
+            "us-gov-west-1-fips" => %{
+              "credentialScope" => %{"region" => "us-gov-west-1"},
+              "hostname" => "bedrock-fips.us-gov-west-1.amazonaws.com"
+            }
+          }
+        },
+        "bedrock-runtime" => %{
+          "defaults" => %{"credentialScope" => %{"service" => "bedrock"}},
+          "endpoints" => %{
+            "us-gov-east-1" => %{},
+            "us-gov-east-1-fips" => %{
+              "credentialScope" => %{"region" => "us-gov-east-1"},
+              "hostname" => "bedrock-runtime-fips.us-gov-east-1.amazonaws.com"
+            },
+            "us-gov-west-1" => %{},
+            "us-gov-west-1-fips" => %{
+              "credentialScope" => %{"region" => "us-gov-west-1"},
+              "hostname" => "bedrock-runtime-fips.us-gov-west-1.amazonaws.com"
+            }
+          }
+        },
+        "bedrock-agent" => %{
+          "defaults" => %{"credentialScope" => %{"service" => "bedrock"}},
+          "endpoints" => %{
+            "us-gov-east-1" => %{},
+            "us-gov-east-1-fips" => %{
+              "credentialScope" => %{"region" => "us-gov-east-1"},
+              "hostname" => "bedrock-agent-fips.us-gov-east-1.amazonaws.com"
+            },
+            "us-gov-west-1" => %{},
+            "us-gov-west-1-fips" => %{
+              "credentialScope" => %{"region" => "us-gov-west-1"},
+              "hostname" => "bedrock-agent-fips.us-gov-west-1.amazonaws.com"
+            }
+          }
+        },
+        "bedrock-agent-runtime" => %{
+          "defaults" => %{"credentialScope" => %{"service" => "bedrock"}},
+          "endpoints" => %{
+            "us-gov-east-1" => %{},
+            "us-gov-east-1-fips" => %{
+              "credentialScope" => %{"region" => "us-gov-east-1"},
+              "hostname" => "bedrock-agent-runtime-fips.us-gov-east-1.amazonaws.com"
+            },
+            "us-gov-west-1" => %{},
+            "us-gov-west-1-fips" => %{
+              "credentialScope" => %{"region" => "us-gov-west-1"},
+              "hostname" => "bedrock-agent-runtime-fips.us-gov-west-1.amazonaws.com"
+            }
+          }
+        },
         "elasticache" => %{"endpoints" => %{"us-gov-east-1" => %{}, "us-gov-west-1" => %{}}},
         "fsx" => %{
           "endpoints" => %{


### PR DESCRIPTION
Discovered that bedrock service was not included in the `aws-us-gov` partition of `endpoint.exs` when we got the error `bedrock-runtime not found in partition aws-us-gov`.

To resolve, copied the bedrock service definitions from the `AWS Standard` partition, replacing the standard region endpoints with gov ones. Also copied over the `fips` version of endpoints from the gov cloud dynamodb service definition, updating hostname to match the services to avoid this issue in the future if someone tries to use fips versions of he bedrock services.

Steps taken to verify PR:
- Tested usage of the `bedrock-runtime` in `us-gov-west-1` through successful usage of the converse stream api.  Operation:
```
%ExAws.Operation.JSON{
        data: body,
        headers: @json_request_headers,
        http_method: :post,
        path: "/model/#{model_id}/converse-stream",
        service: :"bedrock-runtime"
      }
```
- Ran `mix format`
- Ran `mix dializer`
<img width="865" alt="Screenshot 2025-06-27 at 2 00 28 PM" src="https://github.com/user-attachments/assets/9da67c43-b18a-462e-874c-7e3b7eed2e7e" />
- Ran `mix test`
<img width="1047" alt="Screenshot 2025-06-27 at 1 54 00 PM" src="https://github.com/user-attachments/assets/528dc167-d514-4bb5-8fbf-cb104864a953" />