### PR TITLE
Fix bucket_as_host with virtual_host causing double bucket in URLs

### DIFF
--- a/lib/ex_aws/operation/s3.ex
+++ b/lib/ex_aws/operation/s3.ex
@@ -62,6 +62,12 @@ defmodule ExAws.Operation.S3 do
       raise "#{__MODULE__}.perform/2 cannot perform operation on `nil` bucket"
     end
 
+    def add_bucket_to_path(operation, %{virtual_host: true, bucket_as_host: true} = config) do
+      # When bucket_as_host is true, use the bucket name as the full hostname
+      {put_in(operation.path, ensure_absolute(operation.path)),
+       Map.put(config, :host, operation.bucket)}
+    end
+
     def add_bucket_to_path(operation, %{virtual_host: true, host: base_host} = config) do
       vhost_domain = "#{operation.bucket}.#{base_host}"
 

--- a/test/ex_aws/operation/s3_test.exs
+++ b/test/ex_aws/operation/s3_test.exs
@@ -80,4 +80,24 @@ defmodule ExAws.Operation.S3Test do
     {processed_operation, _processed_config} = S3.add_bucket_to_path(operation, config)
     assert processed_operation.path == "/folder/"
   end
+
+  test "S3 uses bucket as host when both virtual_host and bucket_as_host are true" do
+    config = ExAws.Config.new(:s3) |> Map.put(:virtual_host, true) |> Map.put(:bucket_as_host, true)
+    operation = s3_operation("my-custom-domain.com")
+
+    {processed_operation, processed_config} = S3.add_bucket_to_path(operation, config)
+
+    assert(processed_config.host == "my-custom-domain.com")
+    assert(processed_operation.path == "/folder")
+  end
+
+  test "S3 uses standard virtual host when virtual_host is true but bucket_as_host is false" do
+    config = ExAws.Config.new(:s3) |> Map.put(:virtual_host, true) |> Map.put(:bucket_as_host, false)
+    operation = s3_operation()
+
+    {processed_operation, processed_config} = S3.add_bucket_to_path(operation, config)
+
+    assert(processed_config.host == "#{operation.bucket}.#{ExAws.Config.new(:s3).host}")
+    assert(processed_operation.path == "/folder")
+  end
 end


### PR DESCRIPTION
> [!NOTE]
> I've written the code in this PR using Claude 4 and I reviewed the code afterwards.

## Problem
When both `virtual_host=true` and `bucket_as_host=true` are configured, S3 URLs are incorrectly constructed with the bucket domain appearing twice.

For example:
- Expected: `https://my-bucket-domain.com/key`
- Actual: `https://my-bucket-domain.com/my-bucket-domain.com/key`

This affects all S3 operations when using custom domain buckets, including multipart uploads.

## Root Cause
The `add_bucket_to_path` function in `ExAws.Operation.S3` only handled the `virtual_host` option but didn't support the `bucket_as_host` option. When `virtual_host=true`, it always constructed the hostname as `"#{bucket}.#{base_host}"`, even when `bucket_as_host=true` was set.

## Solution
Added proper support for the `bucket_as_host` option by:

1. Adding a new pattern match for when both `virtual_host: true` and `bucket_as_host: true` are set
2. When both are true: Use the bucket name directly as the hostname (don't append to base host)
3. Preserving all existing behavior for other configurations

## Changes
- Modified `add_bucket_to_path/2` in `lib/ex_aws/operation/s3.ex` to handle `bucket_as_host` option
- Added comprehensive tests to verify the new functionality

## Testing
- ✅ `virtual_host: true, bucket_as_host: true`: URLs become `https://my-bucket-domain/key`
- ✅ `virtual_host: true, bucket_as_host: false`: URLs remain `https://bucket.s3.amazonaws.com/key`
- ✅ `virtual_host: false`: URLs remain `https://s3.amazonaws.com/bucket/key`

Fixes ex-aws/ex_aws_s3#306