### PR TITLE
Update FIPS (gov) endpoint "us-gov-east-1" targeting "lambda-fips.us-gov-east-1.amazonaws.c…

### DIFF
--- a/priv/endpoints.exs
+++ b/priv/endpoints.exs
@@ -3170,7 +3170,12 @@ chime_voice_regions = [
           }
         },
         "polly" => %{"endpoints" => %{"us-gov-west-1" => %{}}},
-        "lambda" => %{"endpoints" => %{"us-gov-east-1" => %{}, "us-gov-west-1" => %{}}},
+        "lambda" => %{
+          "endpoints" => %{
+            "us-gov-east-1" => %{"hostname" => "lambda-fips.us-gov-east-1.amazonaws.com"},
+            "us-gov-west-1" => %{"hostname" => "lambda-fips.us-gov-west-1.amazonaws.com"}
+          }
+        },
         "dynamodb" => %{
           "endpoints" => %{
             "us-gov-east-1-fips" => %{


### PR DESCRIPTION
The change brings to use the fips endpoint of us-gov-east-1 and us-gov-west-1.

<img width="668" height="225" alt="Screenshot 2025-09-10 at 13 55 01" src="https://github.com/user-attachments/assets/4c730c9b-d420-4a54-ac83-d91fcfbba8fd" />

<img width="448" height="142" alt="Screenshot 2025-09-10 at 14 01 50" src="https://github.com/user-attachments/assets/2881cbbd-866b-4ce6-ac99-bf445721c569" />


<img width="1266" height="240" alt="Screenshot 2025-09-10 at 13 13 25" src="https://github.com/user-attachments/assets/64a8ae84-0ae1-4199-b457-60a83fe4c7fb" />

[FIPS aws doc](https://aws.amazon.com/compliance/fips/)
