### PR TITLE
Hide warning printed when running tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ config :ex_aws, :retries,
 * `base_backoff_in_ms` corresponds to the `base` value described in the blog post
 * `max_backoff_in_ms` corresponds to the `cap` value described in the blog post
 
-## Testing
+## Testing ExAws
 
 If you want to run `mix test`, you'll need to have a local `dynamodb` running
 on port 8000:
@@ -268,8 +268,6 @@ docker run --rm -d -p 8000:8000 amazon/dynamodb-local -jar DynamoDBLocal.jar -po
 ```
 
 For more info please see [Setting up DynamoDB Local](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.DownloadingAndRunning.html).
-
-The redirect test will intentionally cause a warning to be issued.
 
 ## License
 

--- a/test/ex_aws/request_test.exs
+++ b/test/ex_aws/request_test.exs
@@ -220,6 +220,7 @@ defmodule ExAws.RequestTest do
              )
   end
 
+  @tag capture_log: true
   test "Retries on errors, when the error reason is a map", context do
     ExAws.Request.HttpMock
     |> expect(:request, fn _method, _url, _body, _headers, _opts ->
@@ -243,6 +244,7 @@ defmodule ExAws.RequestTest do
              )
   end
 
+  @tag capture_log: true
   test "Retries on errors, when the error reason is a keyword list", context do
     ExAws.Request.HttpMock
     |> expect(:request, fn _method, _url, _body, _headers, _opts ->


### PR DESCRIPTION
Currently running mix test prints out two warnings in the output:
> ❯ mix test
> Running ExUnit with seed: 615400, max_cases: 16
>
> ...............................................................*.............2025-09-16 18:38:10.527 [warning] ExAws: HTTP ERROR: :closed for URL: "https://examplebucket.s3.amazonaws.com/test.txt" ATTEMPT: 5
> .......2025-09-16 18:38:10.636 [warning] ExAws: HTTP ERROR: :closed for URL: "https://examplebucket.s3.amazonaws.com/test.txt" ATTEMPT: 5
> .
> Finished in 4.0 seconds (0.2s async, 3.7s sync)

This was added in https://github.com/ex-aws/ex_aws/pull/651 which also added the note to the readme, but I don't see any reason that we _want_ the warning to be printed out when the tests are run. So this PR adds `@tag capture_log: true` to hide the warnings and give us a clean test output:

> ❯ mix test
> Running ExUnit with seed: 334627, max_cases: 16
>
> ..............................*......................................................
> Finished in 0.7 seconds (0.1s async, 0.6s sync)

It also updates the "Testing" heading to "Testing ExAws" because it took me a bit to realize that it wasn't about testing your own code that uses ExAws

Checklist:
* [x] Run `mix format` using a recent version of Elixir
* [x] Run `mix dialyzer` to make sure the typing is correct
* [x] Run `mix test` to ensure no tests have broken (also please make sure you've added tests for your particular change, where appropriate).
