### PR TITLE
Fix geo operations

### DIFF
--- a/lib/ex_aws/config/defaults.ex
+++ b/lib/ex_aws/config/defaults.ex
@@ -77,7 +77,17 @@ defmodule ExAws.Config.Defaults do
     |> Map.merge(defaults(:timestream))
   end
 
-  def defaults(service) when service in [:places, :maps, :geofencing, :tracking, :routes] do
+  def defaults(:places) do
+    %{service_override: :"geo-places"}
+    |> Map.merge(defaults(:geo))
+  end
+
+  def defaults(:routes) do
+    %{service_override: :"geo-routes"}
+    |> Map.merge(defaults(:geo))
+  end
+
+  def defaults(service) when service in [:maps, :geofencing, :tracking] do
     %{service_override: :geo}
     |> Map.merge(defaults(:geo))
   end

--- a/lib/ex_aws/config/defaults.ex
+++ b/lib/ex_aws/config/defaults.ex
@@ -77,29 +77,19 @@ defmodule ExAws.Config.Defaults do
     |> Map.merge(defaults(:timestream))
   end
 
-  def defaults(:places) do
+  def defaults(service) when service in [:places, :maps, :geofencing, :tracking, :routes] do
+    %{service_override: :geo}
+    |> Map.merge(defaults(:geo))
+  end
+
+  def defaults(:places_v2) do
     %{service_override: :"geo-places"}
     |> Map.merge(defaults(:"geo-places"))
   end
 
-  def defaults(:routes) do
+  def defaults(:routes_v2) do
     %{service_override: :"geo-routes"}
     |> Map.merge(defaults(:"geo-routes"))
-  end
-
-  def defaults(:maps) do
-    %{service_override: :"geo-maps"}
-    |> Map.merge(defaults(:"geo-maps"))
-  end
-
-  def defaults(:geofencing) do
-    %{service_override: :"geo-geofencing"}
-    |> Map.merge(defaults(:"geo-geofencing"))
-  end
-
-  def defaults(:tracking) do
-    %{service_override: :"geo-tracking"}
-    |> Map.merge(defaults(:"geo-tracking"))
   end
 
   def defaults(chime_service)
@@ -157,11 +147,11 @@ defmodule ExAws.Config.Defaults do
   defp service_map(:iot_data), do: "data.iot"
   defp service_map(:ingest_timestream), do: "ingest.timestream"
   defp service_map(:query_timestream), do: "query.timestream"
-  defp service_map(:places), do: "places.geo"
+  defp service_map(place_service) when place_service in [:places, :places_v2], do: "places.geo"
   defp service_map(:maps), do: "maps.geo"
   defp service_map(:geofencing), do: "geofencing.geo"
   defp service_map(:tracking), do: "tracking.geo"
-  defp service_map(:routes), do: "routes.geo"
+  defp service_map(route_service) when route_service in [:routes, :routes_v2], do: "routes.geo"
 
   defp service_map(service) do
     service

--- a/lib/ex_aws/config/defaults.ex
+++ b/lib/ex_aws/config/defaults.ex
@@ -79,17 +79,27 @@ defmodule ExAws.Config.Defaults do
 
   def defaults(:places) do
     %{service_override: :"geo-places"}
-    |> Map.merge(defaults(:geo))
+    |> Map.merge(defaults(:"geo-places"))
   end
 
   def defaults(:routes) do
     %{service_override: :"geo-routes"}
-    |> Map.merge(defaults(:geo))
+    |> Map.merge(defaults(:"geo-routes"))
   end
 
-  def defaults(service) when service in [:maps, :geofencing, :tracking] do
-    %{service_override: :geo}
-    |> Map.merge(defaults(:geo))
+  def defaults(:maps) do
+    %{service_override: :"geo-maps"}
+    |> Map.merge(defaults(:"geo-maps"))
+  end
+
+  def defaults(:geofencing) do
+    %{service_override: :"geo-geofencing"}
+    |> Map.merge(defaults(:"geo-geofencing"))
+  end
+
+  def defaults(:tracking) do
+    %{service_override: :"geo-tracking"}
+    |> Map.merge(defaults(:"geo-tracking"))
   end
 
   def defaults(chime_service)

--- a/priv/endpoints.exs
+++ b/priv/endpoints.exs
@@ -3405,6 +3405,11 @@ chime_voice_regions = [
             "us-gov-west-1" => %{}
           }
         },
+        "routes.geo" => %{
+          "endpoints" => %{
+            "us-gov-west-1" => %{}
+          }
+        },
         "sso" => %{
           "endpoints" => %{
             "us-gov-east-1" => %{},

--- a/priv/endpoints.exs
+++ b/priv/endpoints.exs
@@ -3400,6 +3400,11 @@ chime_voice_regions = [
         "cloudformation" => %{"endpoints" => %{"us-gov-east-1" => %{}, "us-gov-west-1" => %{}}},
         "swf" => %{"endpoints" => %{"us-gov-east-1" => %{}, "us-gov-west-1" => %{}}},
         "sagemaker" => %{"endpoints" => %{"us-gov-west-1" => %{}}},
+        "places.geo" => %{
+          "endpoints" => %{
+            "us-gov-west-1" => %{}
+          }
+        },
         "sso" => %{
           "endpoints" => %{
             "us-gov-east-1" => %{},


### PR DESCRIPTION
Fix constructing geo requests

Without this change when calling a location services API this message is returned from AWS: `{"message":"Credential should be scoped to correct service: 'geo-places'. "}`

Here's an example request that works after this change (that fails on `main`):
```elixir
operation =
  %ExAws.Operation.JSON{
    http_method: :post,
    path: "/v2/suggest",
    data: %{QueryText: "Elixir", BiasPosition: [157.8, 21.3]},
    service: :places,
    headers: []
  }

ExAws.request(operation)
```

Also ensures that GovCloud supports places, currently was getting: `(RuntimeError) places not found in partition aws-us-gov`

Checklist:
* [x] Run `mix format` using a recent version of Elixir
* [x] Run `mix dialyzer` to make sure the typing is correct
* [x] Run `mix test` to ensure no tests have broken (also please make sure you've added tests for your particular change, where appropriate).
