### PR TITLE
Add eu-north-1 to the list of support regions for AWS SecretsManager

### DIFF
--- a/priv/endpoints.exs
+++ b/priv/endpoints.exs
@@ -2479,6 +2479,7 @@ chime_voice_regions = [
             "ca-central-1" => %{},
             "ca-west-1" => %{},
             "eu-central-1" => %{},
+            "eu-north-1" => %{},
             "eu-west-1" => %{},
             "eu-west-2" => %{},
             "sa-east-1" => %{},


### PR DESCRIPTION
We need to have access to the SecretsManager secrets, and current version doesn't have our region in the list of supported ones.