### PR TITLE
Add us-west-1 region to endpoints configuration for Athena

### DIFF
--- a/priv/endpoints.exs
+++ b/priv/endpoints.exs
@@ -1071,6 +1071,7 @@ chime_voice_regions = [
             "eu-west-2" => %{},
             "us-east-1" => %{},
             "us-east-2" => %{},
+            "us-west-1" => %{},
             "us-west-2" => %{}
           }
         },


### PR DESCRIPTION
### Fixes `athena not supported in region us-west-1 for partition aws`
```
** (RuntimeError) athena not supported in region us-west-1 for partition aws
    (ex_aws 2.5.6) lib/ex_aws/config/defaults.ex:195: ExAws.Config.Defaults.fetch_or/3
    (ex_aws 2.5.6) lib/ex_aws/config/defaults.ex:178: ExAws.Config.Defaults.do_host/3
    (ex_aws 2.5.6) lib/ex_aws/config/defaults.ex:110: ExAws.Config.Defaults.get/2
    (ex_aws 2.5.6) lib/ex_aws/config.ex:96: ExAws.Config.build_base/2
    (ex_aws 2.5.6) lib/ex_aws/config.ex:69: ExAws.Config.new/2
    (ex_aws 2.5.6) lib/ex_aws.ex:73: ExAws.request/2
    iex:1: (file)
```