### PR TITLE
Use http opts configured per http client for pod identity

### DIFF
--- a/lib/ex_aws/pod_identity.ex
+++ b/lib/ex_aws/pod_identity.ex
@@ -61,7 +61,7 @@ defmodule ExAws.PodIdentity do
       credentials_uri ->
         headers = [{"Authorization", token}]
 
-        case config.http_client.request(:get, credentials_uri, "", headers, http_opts())
+        case config.http_client.request(:get, credentials_uri, "", headers)
              |> ExAws.Request.maybe_transform_response() do
           {:ok, %{status_code: 200, body: body}} ->
             case config.json_codec.decode(body) do
@@ -85,15 +85,5 @@ defmodule ExAws.PodIdentity do
       security_token: credentials["Token"],
       expiration: credentials["Expiration"]
     }
-  end
-
-  defp http_opts do
-    defaults = [follow_redirect: false, recv_timeout: 5_000]
-
-    overrides =
-      Application.get_env(:ex_aws, :pod_identity, [])
-      |> Keyword.get(:http_opts, [])
-
-    Keyword.merge(defaults, overrides)
   end
 end


### PR DESCRIPTION
`ExAws.PodIdentity` is not working if Req (`ExAws.Request.Req`) is configured as http_client:
```
iex(1)> ExAws.PodIdentity.security_credentials(%{http_client: ExAws.Request.Req})
** (ArgumentError) unknown option :recv_timeout. Did you mean :receive_timeout?
    (req 0.5.15) lib/req/request.ex:1184: Req.Request.validate_options/2
    (req 0.5.15) lib/req.ex:549: Req.merge/2
    (req 0.5.15) lib/req.ex:1093: Req.request/2
    (ex_aws 2.6.0) lib/ex_aws/request/req.ex:24: ExAws.Request.Req.request/5
    (ex_aws 2.6.0) lib/ex_aws/pod_identity.ex:64: ExAws.PodIdentity.fetch_credentials/2
    (ex_aws 2.6.0) lib/ex_aws/pod_identity.ex:20: ExAws.PodIdentity.security_credentials/1
```