### PR TITLE
Add S3 support for ap-southeast-4 (Melbourne) and ap-southeast-5 (Malaysia)

### DIFF
--- a/priv/endpoints.exs
+++ b/priv/endpoints.exs
@@ -1893,6 +1893,14 @@ chime_voice_regions = [
               "hostname" => "s3.ap-southeast-3.amazonaws.com",
               "signatureVersions" => ["s3", "s3v4"]
             },
+            "ap-southeast-4" => %{
+              "hostname" => "s3.ap-southeast-4.amazonaws.com",
+              "signatureVersions" => ["s3", "s3v4"]
+            },
+            "ap-southeast-5" => %{
+              "hostname" => "s3.ap-southeast-5.amazonaws.com",
+              "signatureVersions" => ["s3", "s3v4"]
+            },
             "af-south-1" => %{
               "hostname" => "s3.af-south-1.amazonaws.com",
               "signatureVersions" => ["s3", "s3v4"]


### PR DESCRIPTION
  - Added ap-southeast-4 region (Asia Pacific - Melbourne)
  - Added ap-southeast-5 region (Asia Pacific - Malaysia)
  - Both regions launched in 2024 and are fully operational
  - Follows same pattern as existing ap-southeast-* regions
