### PR TITLE
Add region eu-south-2 for ec2

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.15
-erlang 26.1.2
+elixir 1.16.2-otp-26
+erlang 26.2.2

--- a/priv/endpoints.exs
+++ b/priv/endpoints.exs
@@ -1196,6 +1196,7 @@ chime_voice_regions = [
             "eu-west-3" => %{},
             "eu-north-1" => %{},
             "eu-south-1" => %{},
+            "eu-south-2" => %{},
             "sa-east-1" => %{},
             "us-east-1" => %{},
             "us-east-2" => %{},

--- a/priv/endpoints.exs
+++ b/priv/endpoints.exs
@@ -1656,6 +1656,7 @@ chime_voice_regions = [
               "signatureVersions" => ["s3", "s3v4"]
             },
             "eu-south-1" => %{},
+            "eu-south-2" => %{},
             "eu-west-2" => %{},
             "eu-west-3" => %{},
             "eu-north-1" => %{},


### PR DESCRIPTION
To fix

```
[stdout] ** (EXIT) shutdown: failed to start child: :ec2_cluster
[stdout] ** (EXIT) an exception was raised:
[stdout] ** (RuntimeError) ec2 not supported in region eu-south-2 for partition aws
[stdout] (ex_aws 2.5.8) lib/ex_aws/config/defaults.ex:195: ExAws.Config.Defaults.fetch_or/3
[stdout] (ex_aws 2.5.8) lib/ex_aws/config/defaults.ex:178: ExAws.Config.Defaults.do_host/3
[stdout] (ex_aws 2.5.8) lib/ex_aws/config/defaults.ex:110: ExAws.Config.Defaults.get/2
[stdout] (ex_aws 2.5.8) lib/ex_aws/config.ex:96: ExAws.Config.build_base/2
[stdout] (ex_aws 2.5.8) lib/ex_aws/config.ex:69: ExAws.Config.new/2
[stdout] (libcluster_ec2 0.8.2) lib/libcluster_ec2.ex:20: ClusterEC2.get_metadata/1
[stdout] (libcluster_ec2 0.8.2) lib/strategy/tags.ex:53: ClusterEC2.Strategy.Tags.init/1
[stdout] (stdlib 7.1) gen_server.erl:2276: :gen_server.init_it/2`
```