### PR TITLE
fix(request): wrap HTTP adapters with Code.ensure_loaded? for optional deps

### DIFF
--- a/lib/ex_aws/request/hackney.ex
+++ b/lib/ex_aws/request/hackney.ex
@@ -1,29 +1,31 @@
-defmodule ExAws.Request.Hackney do
-  @behaviour ExAws.Request.HttpClient
+if Code.ensure_loaded?(:hackney) do
+  defmodule ExAws.Request.Hackney do
+    @behaviour ExAws.Request.HttpClient
 
-  @moduledoc """
-  Configuration for `:hackney`.
+    @moduledoc """
+    Configuration for `:hackney`.
 
-  Options can be set for `:hackney` with the following config:
+    Options can be set for `:hackney` with the following config:
 
-      config :ex_aws, :hackney_opts,
-        recv_timeout: 30_000
+        config :ex_aws, :hackney_opts,
+          recv_timeout: 30_000
 
-  The default config handles setting the above.
-  """
+    The default config handles setting the above.
+    """
 
-  @default_opts [recv_timeout: 30_000]
+    @default_opts [recv_timeout: 30_000]
 
-  def request(method, url, body \\ "", headers \\ [], http_opts \\ []) do
-    opts = Application.get_env(:ex_aws, :hackney_opts, @default_opts)
-    opts = http_opts ++ opts
+    def request(method, url, body \\ "", headers \\ [], http_opts \\ []) do
+      opts = Application.get_env(:ex_aws, :hackney_opts, @default_opts)
+      opts = http_opts ++ opts
 
-    case :hackney.request(method, url, headers, body, opts) do
-      {:ok, status, headers, body} ->
-        {:ok, %{status_code: status, headers: headers, body: body}}
+      case :hackney.request(method, url, headers, body, opts) do
+        {:ok, status, headers, body} ->
+          {:ok, %{status_code: status, headers: headers, body: body}}
 
-      {:error, reason} ->
-        {:error, %{reason: reason}}
+        {:error, reason} ->
+          {:error, %{reason: reason}}
+      end
     end
   end
 end

--- a/lib/ex_aws/request/req.ex
+++ b/lib/ex_aws/request/req.ex
@@ -1,41 +1,43 @@
-defmodule ExAws.Request.Req do
-  @behaviour ExAws.Request.HttpClient
+if Code.ensure_loaded?(Req) do
+  defmodule ExAws.Request.Req do
+    @behaviour ExAws.Request.HttpClient
 
-  @moduledoc """
-  Configuration for `m:Req`.
+    @moduledoc """
+    Configuration for `m:Req`.
 
-  Options can be set for `m:Req` with the following config:
+    Options can be set for `m:Req` with the following config:
 
-      config :ex_aws, :req_opts,
-        receive_timeout: 30_000
+        config :ex_aws, :req_opts,
+          receive_timeout: 30_000
 
-  The default config handles setting the above.
-  """
+    The default config handles setting the above.
+    """
 
-  @default_opts [receive_timeout: 30_000]
+    @default_opts [receive_timeout: 30_000]
 
-  @impl true
-  def request(method, url, body \\ "", headers \\ [], http_opts \\ []) do
-    http_opts = rename_follow_redirect(http_opts)
+    @impl true
+    def request(method, url, body \\ "", headers \\ [], http_opts \\ []) do
+      http_opts = rename_follow_redirect(http_opts)
 
-    [method: method, url: url, body: body, headers: headers, decode_body: false, retry: false]
-    |> Keyword.merge(Application.get_env(:ex_aws, :req_opts, @default_opts))
-    |> Keyword.merge(http_opts)
-    |> Req.request()
-    |> case do
-      {:ok, resp} ->
-        {:ok, %{status_code: resp.status, headers: Req.get_headers_list(resp), body: resp.body}}
+      [method: method, url: url, body: body, headers: headers, decode_body: false, retry: false]
+      |> Keyword.merge(Application.get_env(:ex_aws, :req_opts, @default_opts))
+      |> Keyword.merge(http_opts)
+      |> Req.request()
+      |> case do
+        {:ok, resp} ->
+          {:ok, %{status_code: resp.status, headers: Req.get_headers_list(resp), body: resp.body}}
 
-      {:error, reason} ->
-        {:error, %{reason: reason}}
+        {:error, reason} ->
+          {:error, %{reason: reason}}
+      end
     end
-  end
 
-  # Req >= 0.4.0 uses :redirect, but some clients pass the :hackney option
-  # :follow_redirect. Rename the option for Req to use.
-  defp rename_follow_redirect(opts) do
-    {follow, opts} = Keyword.pop(opts, :follow_redirect, false)
+    # Req >= 0.4.0 uses :redirect, but some clients pass the :hackney option
+    # :follow_redirect. Rename the option for Req to use.
+    defp rename_follow_redirect(opts) do
+      {follow, opts} = Keyword.pop(opts, :follow_redirect, false)
 
-    Keyword.put(opts, :redirect, follow)
+      Keyword.put(opts, :redirect, follow)
+    end
   end
 end


### PR DESCRIPTION
## Problem

Users who don't use Req as their HTTP client see this warning during compilation:

```
warning: Req.request/1 is undefined (module Req is not available or is yet to be defined)
└─ lib/ex_aws/request/req.ex:22:12: ExAws.Request.Req.request/5
```

## Solution

Wrap HTTP client adapter modules with `if Code.ensure_loaded?` so they are only defined when the optional dependency is available at compile time.

This follows the same pattern used by [Tesla for optional adapters](https://github.com/elixir-tesla/tesla/blob/master/lib/tesla/adapter/finch.ex).

## Changes

- `lib/ex_aws/request/req.ex` - wrapped with `if Code.ensure_loaded?(Req)`
- `lib/ex_aws/request/hackney.ex` - wrapped with `if Code.ensure_loaded?(:hackney)` for consistency