### PR TITLE
Fix typo in error message for security credentials

### DIFF
--- a/lib/ex_aws/config.ex
+++ b/lib/ex_aws/config.ex
@@ -229,7 +229,7 @@ defmodule ExAws.Config do
       nil ->
         case credentials_ini_provider.security_credentials(profile) do
           {:ok, creds} -> creds
-          {:error, err} -> raise "Recieved error while retrieving security credentials: #{err}"
+          {:error, err} -> raise "Received error while retrieving security credentials: #{err}"
         end
 
       %{^profile => profile_credentials} ->


### PR DESCRIPTION
I was reading through some log messages this morning and noticed this typo.

Before opening a PR, please make sure you have:

* Run `mix format` using a recent version of Elixir
* Run `mix dialyzer` to make sure the typing is correct
* Run `mix test` to ensure no tests have broken (also please make sure you've added tests for your particular change, where appropriate).
