### PR TITLE
Make auth_refresh_lead_time configurable

### DIFF
--- a/lib/ex_aws/config/auth_cache.ex
+++ b/lib/ex_aws/config/auth_cache.ex
@@ -5,7 +5,7 @@ defmodule ExAws.Config.AuthCache do
 
   # http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html
 
-  @refresh_lead_time 300_000
+  @refresh_lead_time Application.compile_env(:ex_aws, :auth_refresh_lead_time, 300_000)
   @instance_auth_key :aws_instance_auth
   @pod_identity_auth_key :aws_pod_identity_auth
 


### PR DESCRIPTION
## Summary

The `@refresh_lead_time` in `AuthCache` controls how far in advance of credential expiry a refresh is triggered. The hardcoded value of 300,000ms (5 min) means presigned URLs signed with temporary credentials (instance role / ECS task role) can have as little as ~5 minutes of effective validity — AWS rejects requests once the embedded `X-Amz-Security-Token` expires, regardless of `X-Amz-Expires`.

This makes the lead time configurable via application env:

```elixir
config :ex_aws, auth_refresh_lead_time: 7_500_000  # 2h 5min
```

Defaults to `300_000` (5 min), preserving existing behaviour.

## Motivation

When generating presigned S3 URLs that must remain valid for hours (e.g. upload URLs for long-running sessions), the 5-minute refresh window means a URL signed just before credential refresh becomes invalid almost immediately. By allowing consumers to increase the lead time, credentials are refreshed early enough to guarantee sufficient remaining validity on the security token.

## Changes

- `lib/ex_aws/config/auth_cache.ex`: Replace hardcoded `@refresh_lead_time` with `Application.compile_env(:ex_aws, :auth_refresh_lead_time, 300_000)`

No other files changed. No behaviour change for existing users.