### PR TITLE
fix: req support for pod identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 v2.7.0 (2026-03-04)
 - Upgrade hackney to 3.x
+- Correctly handle pod identity authorization when using Req adapter
 
 v2.6.1 (2025-12-09)
 - Endpoint updates

--- a/lib/ex_aws/config.ex
+++ b/lib/ex_aws/config.ex
@@ -233,7 +233,6 @@ defmodule ExAws.Config do
 
           {:error, err} ->
             raise "Received error while retrieving security credentials: #{inspect(err)}"
-
         end
 
       %{^profile => profile_credentials} ->

--- a/lib/ex_aws/request/req.ex
+++ b/lib/ex_aws/request/req.ex
@@ -17,7 +17,7 @@ if Code.ensure_loaded?(Req) do
 
     @impl true
     def request(method, url, body \\ "", headers \\ [], http_opts \\ []) do
-      http_opts = rename_follow_redirect(http_opts)
+      http_opts = http_opts |> rename_follow_redirect() |> rename_recv_timeout()
 
       [method: method, url: url, body: body, headers: headers, decode_body: false, retry: false]
       |> Keyword.merge(Application.get_env(:ex_aws, :req_opts, @default_opts))
@@ -38,6 +38,13 @@ if Code.ensure_loaded?(Req) do
       {follow, opts} = Keyword.pop(opts, :follow_redirect, false)
 
       Keyword.put(opts, :redirect, follow)
+    end
+
+    # Rename :recv_timeout to :receive_timeout for Req to use.
+    defp rename_recv_timeout(opts) do
+      {recv_timeout, opts} = Keyword.pop(opts, :recv_timeout, 30_000)
+
+      Keyword.put(opts, :receive_timeout, recv_timeout)
     end
   end
 end


### PR DESCRIPTION
The current pod identity implementation provides defaults that are merged into other http options. The Pod identity request defaults include :recv_timeout which is incompatible with Req. By following #1095 we can unblock Req adapter users on pod identity implementation. A more robust fix that would also be a breaking change would involve getting the default HTTP options from the adapter itself for various use-cases, and merging those into the implementation.

Before opening a PR, please make sure you have:

* Run `mix format` using a recent version of Elixir
* Run `mix dialyzer` to make sure the typing is correct
* Run `mix test` to ensure no tests have broken (also please make sure you've added tests for your particular change, where appropriate).
