### PR TITLE
fix: Hackney pattern match response when body isn't returned

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ defp deps do
   [
     {:ex_aws, "~> 2.1"},
     {:ex_aws_s3, "~> 2.0"},
-    {:hackney, "~> 1.9"},
+    {:hackney, "~> 4.0"},
     {:sweet_xml, "~> 0.6"},
   ]
 end

--- a/lib/ex_aws/request/hackney.ex
+++ b/lib/ex_aws/request/hackney.ex
@@ -20,6 +20,9 @@ if Code.ensure_loaded?(:hackney) do
       opts = http_opts ++ opts
 
       case :hackney.request(method, url, headers, body, opts) do
+        {:ok, status, headers} ->
+          {:ok, %{status_code: status, headers: headers, body: body}}
+
         {:ok, status, headers, body} ->
           {:ok, %{status_code: status, headers: headers, body: body}}
 


### PR DESCRIPTION
I found a weird case where one of the images couldn't load after I upgraded to Hackney 4. It is a little bit weird that it only happens on that specific image (I didn't debug it further), but there is a case where a response is returned with no body.