### PR TITLE
Don't clobber Req opts with hackney opts

### DIFF
--- a/lib/ex_aws/request/req.ex
+++ b/lib/ex_aws/request/req.ex
@@ -37,14 +37,14 @@ if Code.ensure_loaded?(Req) do
     defp rename_follow_redirect(opts) do
       {follow, opts} = Keyword.pop(opts, :follow_redirect, false)
 
-      Keyword.put(opts, :redirect, follow)
+      Keyword.put_new(opts, :redirect, follow)
     end
 
     # Rename :recv_timeout to :receive_timeout for Req to use.
     defp rename_recv_timeout(opts) do
-      {recv_timeout, opts} = Keyword.pop(opts, :recv_timeout, 30_000)
+      {recv_timeout, opts} = Keyword.pop(opts, :recv_timeout, @default_opts[:receive_timeout])
 
-      Keyword.put(opts, :receive_timeout, recv_timeout)
+      Keyword.put_new(opts, :receive_timeout, recv_timeout)
     end
   end
 end

--- a/test/ex_aws/request/req_test.exs
+++ b/test/ex_aws/request/req_test.exs
@@ -48,4 +48,90 @@ defmodule ExAws.Request.ReqTest do
 
     assert resp.body == ~s|{"attempt":3}|
   end
+
+  describe "Req option renaming" do
+    setup tags do
+      inspect_adapter = fn request ->
+        send(self(), {:request, request})
+        {request, %Req.Response{status: 200, body: "OK"}}
+      end
+
+      http_opts =
+        Map.get(tags, :http_opts, [])
+        |> Keyword.put_new(:adapter, inspect_adapter)
+
+      config = %{
+        http_client: ExAws.Request.Req,
+        http_opts: http_opts,
+        json_codec: Jason,
+        access_key_id: "AKIAIOSFODNN7EXAMPLE",
+        secret_access_key: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+        region: "us-east-1"
+      }
+
+      {:ok, %{config: config}}
+    end
+
+    @tag http_opts: [follow_redirect: true]
+    test "renames :follow_redirect to :redirect", %{config: config} do
+      ExAws.Request.request(:get, "https://test-server", "", [], config, :s3)
+
+      assert_receive {:request, request}
+      assert Map.get(request.options, :redirect) == true
+    end
+
+    @tag http_opts: [redirect: true]
+    test "respects existing redirect", %{config: config} do
+      ExAws.Request.request(:get, "https://test-server", "", [], config, :s3)
+
+      assert_receive {:request, request}
+      assert Map.get(request.options, :redirect) == true
+    end
+
+    @tag http_opts: [redirect: false, follow_redirect: true]
+    test "prefers Req's redirect to hackney's follow_redirect", %{config: config} do
+      ExAws.Request.request(:get, "https://test-server", "", [], config, :s3)
+
+      assert_receive {:request, request}
+      assert Map.get(request.options, :redirect) == false
+    end
+
+    test "uses default redirect when none is provided", %{config: config} do
+      ExAws.Request.request(:get, "https://test-server", "", [], config, :s3)
+
+      assert_receive {:request, request}
+      assert Map.get(request.options, :redirect) == false
+    end
+
+    @tag http_opts: [recv_timeout: 10_000]
+    test "renames :recv_timeout to :receive_timeout", %{config: config} do
+      ExAws.Request.request(:get, "https://test-server", "", [], config, :s3)
+
+      assert_receive {:request, request}
+      assert Map.get(request.options, :receive_timeout) == 10_000
+    end
+
+    @tag http_opts: [receive_timeout: 10_000]
+    test "respects existing receive_timeout", %{config: config} do
+      ExAws.Request.request(:get, "https://test-server", "", [], config, :s3)
+
+      assert_receive {:request, request}
+      assert Map.get(request.options, :receive_timeout) == 10_000
+    end
+
+    @tag http_opts: [receive_timeout: 10_000, recv_timeout: 20_000]
+    test "prefers Req's receive_timeout to hackney's recv_timeout", %{config: config} do
+      ExAws.Request.request(:get, "https://test-server", "", [], config, :s3)
+
+      assert_receive {:request, request}
+      assert Map.get(request.options, :receive_timeout) == 10_000
+    end
+
+    test "uses default receive_timeout when none is provided", %{config: config} do
+      ExAws.Request.request(:get, "https://test-server", "", [], config, :s3)
+
+      assert_receive {:request, request}
+      assert Map.get(request.options, :receive_timeout) == 30_000
+    end
+  end
 end


### PR DESCRIPTION
ExAws v2.7.0 introduced a regression in which a Req-compatible option (`receive_timeout`) gets overwritten by a default if included in `http_opts`. The same issue already existed with the `redirect` option.

This PR replaces `Keyword.put` with `Keyword.put_new` to preserve the existing target option if it already exists, and adds tests for all cases (Req option present, hackney option present, both options present, no option present).

- [x] `mix format`
- [x] `mix dialyzer`
- [x] `mix test`