### PR TITLE
fix(imds): always PUT IMDSv2 token to 169.254.169.254

### DIFF
--- a/lib/ex_aws/instance_meta_token_provider.ex
+++ b/lib/ex_aws/instance_meta_token_provider.ex
@@ -7,9 +7,6 @@ defmodule ExAws.InstanceMetaTokenProvider do
   @metadata_token_ttl_seconds 6 * 60 * 60
   @genserver_call_timeout_seconds 30
   @metadata_token_api_url "http://169.254.169.254/latest/api/token"
-  # Endpoint for ECS tasks role credentials
-  # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html
-  @task_role_root "http://169.254.170.2"
   # The header we pass to control the token's time to live
   @metadata_token_ttl_header_name "x-aws-ec2-metadata-token-ttl-seconds"
   # The header we use to pass the token along to all other metadata calls
@@ -105,11 +102,14 @@ defmodule ExAws.InstanceMetaTokenProvider do
     end
   end
 
+  # The IMDSv2 session-token PUT must always target the EC2 Instance Metadata
+  # Service (169.254.169.254). The ECS task-role credentials endpoint
+  # (169.254.170.2, selected via AWS_CONTAINER_CREDENTIALS_RELATIVE_URI) does
+  # not issue IMDSv2 tokens, so routing the token PUT there yields a bogus
+  # "token" and every subsequent IMDS GET is rejected with a 401. See
+  # ExAws.InstanceMeta.request/3, which is hardcoded to hit 169.254.169.254.
   defp metadata_token_api_url do
-    case System.get_env("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI") do
-      nil -> @metadata_token_api_url
-      uri -> @task_role_root <> uri
-    end
+    @metadata_token_api_url
   end
 
   defp token_ttl_seconds_headers(_config) do

--- a/test/ex_aws/instance_meta_test.exs
+++ b/test/ex_aws/instance_meta_test.exs
@@ -118,5 +118,39 @@ defmodule ExAws.InstanceMetaTest do
 
       assert ExAws.InstanceMeta.instance_role(config) == role_name
     end
+
+    test "token request targets the EC2 metadata endpoint even when running in ECS" do
+      # ECS sets AWS_CONTAINER_CREDENTIALS_RELATIVE_URI in every task. The
+      # task-role credentials endpoint (169.254.170.2) does not issue IMDSv2
+      # tokens, so the token PUT must still go to 169.254.169.254 — otherwise
+      # the credentials-endpoint response body is used as a bogus token and
+      # all subsequent metadata requests fail with a 401.
+      System.put_env("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI", "/v2/credentials/dummy-id")
+      on_exit(fn -> System.delete_env("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI") end)
+
+      role_name = "dummy-role-ecs"
+
+      ExAws.Request.HttpMock
+      |> expect(:request, fn :put, url, _body, _headers, _opts ->
+        assert url == "http://169.254.169.254/latest/api/token"
+        {:ok, %{status_code: 200, body: "dummy-token"}}
+      end)
+      |> expect(:request, fn :get, _url, _body, headers, _opts ->
+        assert Enum.member?(headers, {"x-aws-ec2-metadata-token", "dummy-token"})
+        {:ok, %{status_code: 200, body: role_name}}
+      end)
+
+      config =
+        ExAws.Config.new(:s3,
+          http_client: ExAws.Request.HttpMock,
+          access_key_id: "dummy",
+          secret_access_key: "dummy",
+          # Don't cache the metadata token, so we can always expect a request to get the token
+          no_metadata_token_cache: true,
+          require_imds_v2: true
+        )
+
+      assert ExAws.InstanceMeta.instance_role(config) == role_name
+    end
   end
 end


### PR DESCRIPTION
## Problem

`ExAws.InstanceMetaTokenProvider` routes the IMDSv2 session-token PUT to the ECS task-role credentials endpoint (`169.254.170.2` + `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI`) whenever that environment variable is set — which is the case in every ECS task with a task IAM role.

That endpoint is a credentials-only GET interface; it does not issue IMDSv2 tokens ([SDK container credential provider docs](https://docs.aws.amazon.com/sdkref/latest/guide/feature-container-credentials.html)). Its response body gets cached as a bogus token, and every subsequent metadata GET — which `ExAws.InstanceMeta.request/3` correctly sends to `169.254.169.254` — fails with `401 Unauthorized`.

In practice this breaks any IMDS usage from ECS tasks on EC2 container instances with IMDSv2 required (e.g. `ExAws.InstanceMeta.instance_role/1`, or libraries like `libcluster_ec2` calling the EC2 API through ExAws). We hit this running an Elixir cluster on ECS-on-EC2 with host networking.

## Fix

The token PUT now always targets the real IMDS token endpoint, `http://169.254.169.254/latest/api/token` ([EC2 IMDSv2 docs](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html)). The ECS credentials endpoint is unaffected — it is served by the separate task-role credentials path, which needs no IMDS token.

Includes a regression test asserting the token PUT URL stays `169.254.169.254` when `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` is set; it fails on main and passes with this change.

Checked: `mix format` (Elixir 1.19.5), `mix test` (98 tests, 0 failures, with local DynamoDB), `mix dialyzer` (0 errors).