### PR TITLE
Add EC2 support for ap-southeast-5 (Malaysia) region

### DIFF
--- a/priv/endpoints.exs
+++ b/priv/endpoints.exs
@@ -1206,6 +1206,7 @@ chime_voice_regions = [
             "ap-south-2" => %{},
             "ap-southeast-1" => %{},
             "ap-southeast-2" => %{},
+            "ap-southeast-5" => %{},
             "ca-central-1" => %{},
             "ca-west-1" => %{},
             "eu-central-1" => %{},


### PR DESCRIPTION
Follow-up to #1178, which added ap-southeast-5 for S3: the region was still missing from the `ec2` endpoints map, so any EC2 API call in that region raises `ExAws.Error` ("ec2 not supported in region ap-southeast-5"). We hit this via `libcluster_ec2`, which discovers BEAM cluster peers through EC2 `DescribeInstances`.

One-line addition to `priv/endpoints.exs`, mirroring #1178.

Checked: `mix format` (Elixir 1.19.5), `mix test` (97 tests, 0 failures, with local DynamoDB), `mix dialyzer` (0 errors).